### PR TITLE
perf(queue): cut redis round-trips out of the worker hot path

### DIFF
--- a/bench/e2e.ts
+++ b/bench/e2e.ts
@@ -1,0 +1,218 @@
+/**
+ * End-to-end benchmark. Spins a real Redis (testcontainers, same image as the tests) and drives
+ * the public API — `run()` / `work()` / `job.wait()` — so every number includes serialization,
+ * the Lua round-trips, the worker wake loop and pub/sub delivery.
+ *
+ * Run: `pnpm bench`.
+ */
+
+import { randomUUID } from 'node:crypto'
+import { RedisContainer } from '@testcontainers/redis'
+import { createRedis, WorkflowNamespace } from '../src'
+
+/** Runs per scenario. Throughput on a shared box is noisy; the best run is the least polluted. */
+const RUNS = 3
+
+function report(name: string, value: string, note: string) {
+  console.log(`  ${name.padEnd(34)} ${value.padStart(10)} ${note}`)
+}
+
+/** Best of `RUNS` — the run least disturbed by the rest of the machine. */
+async function best(name: string, run: () => Promise<number>) {
+  const samples: number[] = []
+  for (let i = 0; i < RUNS; i++) samples.push(await run())
+  report(name, Math.max(...samples).toFixed(0), `ops/s (worst=${Math.min(...samples).toFixed(0)})`)
+}
+
+function quantile(sorted: number[], q: number) {
+  return sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * q))]!
+}
+
+interface RedisAddr {
+  host: string
+  port: number
+}
+
+/**
+ * A namespace with a fresh id (key isolation) on its own connection — `namespace.close()`
+ * disconnects the connection it was handed, so scenarios cannot share one.
+ */
+async function makeNamespace(addr: RedisAddr, opts?: { concurrency?: number }) {
+  return new WorkflowNamespace({
+    id: randomUUID(),
+    redis: await createRedis(addr),
+    autoClose: false,
+    concurrency: opts?.concurrency,
+    // A silently failing job would just stall the scenario forever — make it loud.
+    logger: { error: console.error, warn: console.warn },
+  })
+}
+
+/** Enqueue `count` jobs through `run()`, `parallel` at a time. */
+async function enqueueAll(run: (i: number) => Promise<unknown>, count: number, parallel: number) {
+  for (let i = 0; i < count; i += parallel) {
+    await Promise.all(
+      Array.from({ length: Math.min(parallel, count - i) }, async (_, k) => run(i + k)),
+    )
+  }
+}
+
+/** Resolves once `count` jobs have been observed by the worker handler. */
+function makeCounter(count: number) {
+  let seen = 0
+  const { promise, resolve: done, reject: fail } = Promise.withResolvers<void>()
+  // A job that dies (or never gets reserved) would otherwise hang the run forever.
+  const timer = setTimeout(() => fail(new Error(`only ${seen}/${count} jobs ran`)), 120_000)
+  return {
+    hit: () => {
+      if (++seen !== count) return
+      clearTimeout(timer)
+      done()
+    },
+    promise,
+  }
+}
+
+/** Producer-side cost of `run()`: superjson + the `enqueue` script, no worker running. */
+async function benchEnqueue(addr: RedisAddr) {
+  const count = 5000
+  const ns = await makeNamespace(addr)
+  const wf = ns.createWorkflow({
+    id: 'enqueue',
+    schema: undefined,
+    run: async () => 1,
+  })
+
+  await wf.run(undefined) // warm the lazy queue + script load
+
+  for (const parallel of [1, 50]) {
+    await best(`enqueue (${parallel === 1 ? 'serial' : `${parallel} inflight`})`, async () => {
+      const start = performance.now()
+      await enqueueAll(async () => wf.run(undefined), count, parallel)
+      return (count / (performance.now() - start)) * 1000
+    })
+  }
+
+  await ns.close()
+}
+
+interface DrainOptions {
+  name: string
+  count: number
+  concurrency: number
+  groups: number
+  steps: number
+}
+
+/** Steady-state drain: jobs are all enqueued up front, then a worker chews through them. */
+async function benchThroughput(addr: RedisAddr, opts: DrainOptions) {
+  await best(opts.name, async () => runDrain(addr, opts))
+}
+
+async function runDrain(addr: RedisAddr, { count, concurrency, groups, steps }: DrainOptions) {
+  const ns = await makeNamespace(addr)
+  const counter = makeCounter(count)
+  const wf = ns.createWorkflow({
+    id: 'throughput',
+    schema: undefined as never,
+    async run({ step }) {
+      for (let s = 0; s < steps; s++) await step.do(`s${s}`, () => s)
+      counter.hit()
+      return 1
+    },
+  })
+
+  await enqueueAll(
+    async (i) => wf.run({ i } as never, { groupId: groups === 0 ? undefined : `g${i % groups}` }),
+    count,
+    100,
+  )
+
+  const start = performance.now()
+  const worker = await wf.work({ concurrency })
+  await counter.promise
+  const elapsed = performance.now() - start
+
+  await worker.close()
+  await ns.close()
+  return (count / elapsed) * 1000
+}
+
+/** Full round trip a client actually feels: enqueue → execute → pub/sub notify → result read. */
+async function benchLatency(addr: RedisAddr) {
+  const count = 300
+  const ns = await makeNamespace(addr)
+  const wf = ns.createWorkflow({
+    id: 'latency',
+    schema: undefined as never,
+    run: async () => 1,
+  })
+  const worker = await wf.work({ concurrency: 1 })
+
+  const warmup = await wf.run(undefined as never)
+  await warmup.wait()
+
+  const samples: number[] = []
+  for (let i = 0; i < count * RUNS; i++) {
+    const start = performance.now()
+    const job = await wf.run(undefined as never)
+    await job.wait()
+    samples.push(performance.now() - start)
+  }
+  samples.sort((a, b) => a - b)
+
+  const mean = samples.reduce((a, b) => a + b, 0) / samples.length
+  report(
+    'run → wait round trip',
+    mean.toFixed(2),
+    `ms (p50=${quantile(samples, 0.5).toFixed(2)}, p99=${quantile(samples, 0.99).toFixed(2)})`,
+  )
+
+  await worker.close()
+  await ns.close()
+}
+
+async function main() {
+  const container = await new RedisContainer('redis:7-alpine').start()
+  const addr = { host: container.getHost(), port: container.getPort() }
+
+  try {
+    console.log('\nbench: @falcondev-oss/workflow (e2e)\n')
+
+    await benchEnqueue(addr)
+    await benchThroughput(addr, {
+      name: 'drain 1 worker c=1',
+      count: 500,
+      concurrency: 1,
+      groups: 0,
+      steps: 0,
+    })
+    await benchThroughput(addr, {
+      name: 'drain 1 worker c=50',
+      count: 3000,
+      concurrency: 50,
+      groups: 0,
+      steps: 0,
+    })
+    await benchThroughput(addr, {
+      name: 'drain c=50, 3 steps',
+      count: 1000,
+      concurrency: 50,
+      groups: 0,
+      steps: 3,
+    })
+    await benchThroughput(addr, {
+      name: 'drain c=50, 10 groups',
+      count: 1000,
+      concurrency: 50,
+      groups: 10,
+      steps: 0,
+    })
+    await benchLatency(addr)
+    console.log()
+  } finally {
+    await container.stop({ remove: true, removeVolumes: true })
+  }
+}
+
+await main()

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache . && prettier --check --cache .",
     "lint:ci": "eslint --cache --cache-strategy content . && prettier --check --cache --cache-strategy content .",
-    "lint:fix": "eslint --fix --cache . && prettier --write --cache ."
+    "lint:fix": "eslint --fix --cache . && prettier --write --cache .",
+    "bench": "tsx bench/e2e.ts"
   },
   "dependencies": {
     "@antfu/utils": "^9.3.0",

--- a/src/queue/namespace.ts
+++ b/src/queue/namespace.ts
@@ -18,7 +18,7 @@ export class Namespace {
 
   private readonly subscriber: Redis
   private readonly subscriberReady: Promise<unknown>
-  private readonly channelListeners = new Map<string, Set<() => void>>()
+  private readonly channelListeners = new Map<string, Set<(message: string) => void>>()
   private readonly queues = new Set<Queue>()
 
   constructor(opts: NamespaceOptions) {
@@ -30,8 +30,8 @@ export class Namespace {
 
     this.subscriber = opts.redis.duplicate()
     this.subscriberReady = this.subscriber.connect().catch(() => {})
-    this.subscriber.on('message', (channel: string) => {
-      for (const cb of this.channelListeners.get(channel) ?? []) cb()
+    this.subscriber.on('message', (channel: string, message: string) => {
+      for (const cb of this.channelListeners.get(channel) ?? []) cb(message)
     })
   }
 
@@ -42,7 +42,7 @@ export class Namespace {
   }
 
   /** Register a waiter on a pub/sub channel; subscribes on first listener. */
-  async addWaiter(channel: string, cb: () => void): Promise<void> {
+  async addWaiter(channel: string, cb: (message: string) => void): Promise<void> {
     await this.subscriberReady
     let set = this.channelListeners.get(channel)
     if (!set) {
@@ -54,7 +54,7 @@ export class Namespace {
   }
 
   /** Remove a waiter; unsubscribes once the channel has no listeners. */
-  async removeWaiter(channel: string, cb: () => void): Promise<void> {
+  async removeWaiter(channel: string, cb: (message: string) => void): Promise<void> {
     const set = this.channelListeners.get(channel)
     if (!set) return
     set.delete(cb)

--- a/src/queue/queue.ts
+++ b/src/queue/queue.ts
@@ -88,14 +88,16 @@ export class Queue {
   /**
    * Block until `jobId` finishes and return its raw result string. Subscribes to the
    * done channel *before* reading the result key, so the terminal publish can't be missed.
+   * The publish carries the result record itself, so the common path is one `GET` (the
+   * already-finished check) and then the notification — never a second read.
    * Throws `TimeoutError`, `ResultExpiredError`, or the job's own failure.
    */
   async wait(jobId: string, opts?: WaitOptions): Promise<string> {
     const channel = `${this.prefix}:${this.id}:done:${jobId}`
     const resultKey = `${this.prefix}:${this.id}:result:${jobId}`
 
-    let notify!: () => void
-    const notified = new Promise<void>((resolve) => {
+    let notify!: (message: string) => void
+    const notified = new Promise<string>((resolve) => {
       notify = resolve
     })
     await this.ns.addWaiter(channel, notify)
@@ -103,23 +105,20 @@ export class Queue {
       const first = await this.redis.get(resultKey)
       if (first !== null) return this.parseResult(first)
 
-      if (opts?.timeoutMs === undefined) {
-        await notified
-      } else {
-        let timer: NodeJS.Timeout
-        const timedOut = new Promise<'timeout'>((resolve) => {
-          timer = setTimeout(() => resolve('timeout'), opts.timeoutMs)
-        })
-        const outcome = await Promise.race([notified.then(() => 'done' as const), timedOut])
-        clearTimeout(timer!)
-        if (outcome === 'timeout') throw new TimeoutError(jobId)
-      }
+      if (opts?.timeoutMs === undefined) return await this.resolvePublished(jobId, await notified)
 
-      const result = await this.redis.get(resultKey)
-      if (result === null) throw new ResultExpiredError(jobId)
-      return this.parseResult(result)
+      let timer: NodeJS.Timeout
+      const timedOut = new Promise<null>((resolve) => {
+        timer = setTimeout(() => resolve(null), opts.timeoutMs)
+      })
+      const published = await Promise.race([notified, timedOut])
+      clearTimeout(timer!)
+      if (published === null) throw new TimeoutError(jobId)
+      return await this.resolvePublished(jobId, published)
     } finally {
-      await this.ns.removeWaiter(channel, notify)
+      // Fire-and-forget: the unsubscribe is ordered on the subscriber connection ahead of any
+      // later subscribe, so nothing is lost by not making the caller pay its round-trip.
+      void this.ns.removeWaiter(channel, notify).catch((err) => this.logger?.error?.(err))
     }
   }
 
@@ -128,9 +127,21 @@ export class Queue {
     await this.redis.hset(`${this.prefix}:${this.id}:j:${jobId}:steps`, stepName, value)
   }
 
-  /** Read a step's data — a single `HGET`, `null` on miss. Opaque string, no deserialization. */
-  async getStepData(jobId: string, stepName: string): Promise<string | null> {
-    return this.redis.hget(`${this.prefix}:${this.id}:j:${jobId}:steps`, stepName)
+  /**
+   * Turn a `done` publish into the result. The finalize scripts publish the record itself, so
+   * this is normally pure JS — no second read of the key the notification just carried.
+   *
+   * The fallback is not dead: the payload is a wire format shared with *other processes*, which
+   * may be running an older build whose `complete` publishes a bare `"1"`. During any rolling
+   * deploy both shapes are on the channel at once, so a non-record payload is treated as a bare
+   * wake-up and re-read from the result key (`ResultExpiredError` if it has aged out) — exactly
+   * the pre-change behaviour.
+   */
+  private async resolvePublished(jobId: string, published: string): Promise<string> {
+    if (published.startsWith('{')) return this.parseResult(published)
+    const stored = await this.redis.get(`${this.prefix}:${this.id}:result:${jobId}`)
+    if (stored === null) throw new ResultExpiredError(jobId)
+    return this.parseResult(stored)
   }
 
   private parseResult(raw: string): string {

--- a/src/queue/scripts.ts
+++ b/src/queue/scripts.ts
@@ -105,9 +105,10 @@ local function finalizeFailed(prefix, wfId, jobId, reason, stack, resultTtl, gro
     redis.call("ZREMRANGEBYRANK", failedKey, 0, excess - 1)
   end
 
-  redis.call("SET", wf .. ":result:" .. jobId,
-    cjson.encode({ state = "failed", reason = reason, stack = stack }), "EX", resultTtl)
-  redis.call("PUBLISH", wf .. ":done:" .. jobId, "1")
+  local record = cjson.encode({ state = "failed", reason = reason, stack = stack })
+  redis.call("SET", wf .. ":result:" .. jobId, record, "EX", resultTtl)
+  -- The record travels in the publish payload, so a waiter never re-reads the key it just got.
+  redis.call("PUBLISH", wf .. ":done:" .. jobId, record)
 end
 `
 
@@ -212,20 +213,32 @@ return 1
 `
 
 /**
- * The hot path. Delayed-job promotion is embedded at the top: due jobs
- * (`ZRANGEBYSCORE delayed -inf now`, batch-capped) are `ZREM`'d and moved into waiting via
- * the shared `addWaiting` — atomic under Lua's single thread ⇒ exactly-once across concurrent
- * workers, and promoting in `runAt` order stamps `pc` ascending-by-due-time
- * (FIFO-by-ready-time). Then O(1) top-gates → pop head group of
- * `ready` → `ZPOPMIN` its head job → all-or-nothing claim into the three active structures
- * + lock + `state=active` → ready-set maintenance.
+ * The hot path, and the worker's *only* per-iteration round-trip: it claims a batch, promotes
+ * due delayed jobs, and reports everything the wake loop needs to decide its next block —
+ * so an idle or saturated worker costs exactly one command per wake, not four.
  *
- * Returns `{"maxed"}`, `{"empty", msToNext}`, or
- * `{"job", jobId, groupId, data, attempts, priority}`. `msToNext` is the ms until the next
- * due delayed job (`-1` if none, `0` if due work remains past the promote cap) — an idle
- * worker uses it as its `BRPOP wake` timeout, so the block itself is the delayed-job timer.
+ * Delayed-job promotion is embedded at the top: due jobs (`ZRANGEBYSCORE delayed -inf now`,
+ * batch-capped) are `ZREM`'d and moved into waiting via the shared `addWaiting` — atomic under
+ * Lua's single thread ⇒ exactly-once across concurrent workers, and promoting in `runAt` order
+ * stamps `pc` ascending-by-due-time (FIFO-by-ready-time). Then, up to `want` times: O(1)
+ * top-gates → pop head group of `ready` → `ZPOPMIN` its head job → all-or-nothing claim into the
+ * three active structures + lock + `state=active` → ready-set maintenance. Claiming `want` jobs
+ * in one call is what makes a high-concurrency worker cost ~1 reserve per *batch* instead of per
+ * job; `want = 0` (locally saturated) still promotes and reports, it just claims nothing.
  *
- * ARGV: prefix, wfId, nsId, nsCap, wfCap, groupCap, lockMs, token, promoteCap
+ * Claim tokens are derived in-script as `<tokenPrefix>:<n>` from the one UUID the caller passes,
+ * so a batch needs a single JS UUID and the tokens stay globally unique.
+ *
+ * Returns `{ jobs, msToNext, msToSchedule, dueSchedules, maxed }`:
+ * - `jobs`: array of `{ jobId, groupId, data, attempts, priority, token, steps }`, where `steps`
+ *   is the job's memoized step hash flattened to `[name, value, …]`
+ * - `msToNext`: ms until the next due delayed job (`-1` none, `0` due work left behind by the
+ *   promote cap) — the worker's `BRPOP wake` timeout, so the block *is* the delayed-job timer
+ * - `msToSchedule`: same, for the nearest cron occurrence
+ * - `dueSchedules`: `{ scheduleId, score, … }` of schedules due now, for the JS cron tick
+ * - `maxed`: 1 when a concurrency ceiling (not an empty queue) stopped the batch
+ *
+ * ARGV: prefix, wfId, nsId, nsCap, wfCap, groupCap, lockMs, tokenPrefix, promoteCap, want
  */
 const RESERVE = `
 ${MAINTAIN_GROUP}
@@ -237,14 +250,16 @@ local nsCap = tonumber(ARGV[4])
 local wfCap = tonumber(ARGV[5])
 local groupCap = tonumber(ARGV[6])
 local lockMs = tonumber(ARGV[7])
-local token = ARGV[8]
+local tokenPrefix = ARGV[8]
 local promoteCap = tonumber(ARGV[9])
+local want = tonumber(ARGV[10])
 
 local wf = prefix .. ":" .. wfId
 local nsActive = prefix .. ":ns:" .. nsId .. ":active"
 local wfActive = wf .. ":active"
 local readyKey = wf .. ":ready"
 local delayedKey = wf .. ":delayed"
+local scheduleDueKey = wf .. ":schedules:due"
 ${NOW}
 
 -- Promote due delayed jobs (batch-capped). ZRANGEBYSCORE ascending ⇒ promote in runAt order.
@@ -257,47 +272,55 @@ for i = 1, #due do
   addWaiting(wf, djKey, dj, meta[1], tonumber(meta[2]), groupCap)
 end
 
--- ms until the next delayed job is due (for an idle worker BRPOP timeout). Returns 0 when
--- work is already due but was left behind by the promote cap, so the worker re-reserves now.
-local function msToNext()
-  local next = redis.call("ZRANGE", delayedKey, 0, 0, "WITHSCORES")
+-- ms until the head of a due-scored ZSET (for an idle worker BRPOP timeout). Returns 0 when
+-- work is already due, so the worker loops back instead of blocking.
+local function msToHead(key)
+  local next = redis.call("ZRANGE", key, 0, 0, "WITHSCORES")
   if #next == 0 then return -1 end
   local d = tonumber(next[2]) - now
   if d < 0 then return 0 end
   return d
 end
 
-if redis.call("SCARD", nsActive) >= nsCap then return { "maxed" } end
-if redis.call("ZCARD", wfActive) >= wfCap then return { "maxed" } end
+local jobs = {}
+local maxed = 0
+while #jobs < want do
+  if redis.call("SCARD", nsActive) >= nsCap or redis.call("ZCARD", wfActive) >= wfCap then
+    maxed = 1
+    break
+  end
+  local head = redis.call("ZRANGE", readyKey, 0, 0)
+  if #head == 0 then break end
+  local gid = head[1]
+  local popped = redis.call("ZPOPMIN", wf .. ":g:" .. gid .. ":jobs")
+  if #popped == 0 then
+    -- ready pointed at a drained group; fix the membership and try the next one.
+    maintainGroup(wf, gid, groupCap)
+  else
+    local jobId = popped[1]
+    local jobKey = wf .. ":j:" .. jobId
+    local deadline = now + lockMs
+    local token = tokenPrefix .. ":" .. #jobs
 
-local head = redis.call("ZRANGE", readyKey, 0, 0)
-if #head == 0 then return { "empty", msToNext() } end
-local gid = head[1]
+    redis.call("ZADD", wfActive, deadline, jobId)
+    redis.call("SADD", wf .. ":g:" .. gid .. ":active", jobId)
+    redis.call("SADD", nsActive, wfId .. ":" .. jobId)
+    redis.call("SET", jobKey .. ":lock", token, "PX", lockMs)
+    -- Store the popped packed score so stalled-recovery can requeue at the front of its band.
+    redis.call("HSET", jobKey, "state", "active", "deadlineAt", deadline, "score", popped[2])
 
-local groupJobs = wf .. ":g:" .. gid .. ":jobs"
-local groupActive = wf .. ":g:" .. gid .. ":active"
+    maintainGroup(wf, gid, groupCap)
 
-local popped = redis.call("ZPOPMIN", groupJobs)
-if #popped == 0 then
-  maintainGroup(wf, gid, groupCap)
-  return { "empty", msToNext() }
+    -- The claim makes this worker the only writer of the step hash, so shipping it with the
+    -- job is an exact snapshot: a replay resolves memoized steps with no round-trip at all.
+    local vals = redis.call("HMGET", jobKey, "data", "priority", "attempts")
+    local steps = redis.call("HGETALL", jobKey .. ":steps")
+    jobs[#jobs + 1] = { jobId, gid, vals[1], vals[3], vals[2], token, steps }
+  end
 end
-local jobId = popped[1]
 
-local jobKey = wf .. ":j:" .. jobId
-local deadline = now + lockMs
-
-redis.call("ZADD", wfActive, deadline, jobId)
-redis.call("SADD", groupActive, jobId)
-redis.call("SADD", nsActive, wfId .. ":" .. jobId)
-redis.call("SET", jobKey .. ":lock", token, "PX", lockMs)
--- Store the popped packed score so stalled-recovery can requeue at the front of its band.
-redis.call("HSET", jobKey, "state", "active", "deadlineAt", deadline, "score", popped[2])
-
-maintainGroup(wf, gid, groupCap)
-
-local vals = redis.call("HMGET", jobKey, "data", "priority", "attempts")
-return { "job", jobId, gid, vals[1], vals[3], vals[2] }
+local dueSchedules = redis.call("ZRANGEBYSCORE", scheduleDueKey, "-inf", now, "WITHSCORES")
+return { jobs, msToHead(delayedKey), msToHead(scheduleDueKey), dueSchedules, maxed }
 `
 
 /**
@@ -332,7 +355,8 @@ releaseActive(prefix, wfId, jobId, groupCap)
 redis.call("DEL", jobKey)
 redis.call("DEL", jobKey .. ":steps")
 redis.call("SET", wf .. ":result:" .. jobId, result, "EX", resultTtl)
-redis.call("PUBLISH", wf .. ":done:" .. jobId, "1")
+-- The record travels in the publish payload, so a waiter never re-reads the key it just got.
+redis.call("PUBLISH", wf .. ":done:" .. jobId, result)
 return 1
 `
 
@@ -557,7 +581,25 @@ return { "fired", jobId }
 
 export interface QueueCommands {
   enqueue: (...args: (string | number)[]) => Promise<number>
-  reserve: (...args: (string | number)[]) => Promise<(string | number)[]>
+  reserve: (
+    ...args: (string | number)[]
+  ) => Promise<
+    [
+      jobs: [
+        id: string,
+        groupId: string,
+        data: string,
+        attempts: string,
+        priority: string,
+        token: string,
+        steps: string[],
+      ][],
+      msToNext: number,
+      msToSchedule: number,
+      due: string[],
+      maxed: number,
+    ]
+  >
   complete: (...args: (string | number)[]) => Promise<number>
   fail: (...args: (string | number)[]) => Promise<number>
   moveToFailed: (...args: (string | number)[]) => Promise<number>

--- a/src/queue/types.ts
+++ b/src/queue/types.ts
@@ -132,6 +132,11 @@ export interface ReservedJob {
   data: string
   attemptsMade: number
   priority: number
+  /**
+   * The job's persisted step data, read atomically with the claim. Empty on a first attempt;
+   * on a replay it is the complete memo, so resolving a cached step costs no round-trip.
+   */
+  steps: Map<string, string>
 }
 
 export interface JobContext {

--- a/src/queue/worker.ts
+++ b/src/queue/worker.ts
@@ -9,21 +9,48 @@ import { localTimeZone, nextRunMs } from './schedule'
 
 export type WorkerHandler = (job: ReservedJob, ctx: JobContext) => Promise<string> | string
 
+/**
+ * Max jobs claimed per `reserve`. Redis runs Lua single-threaded, so the batch is a pause for
+ * every* client sharing the instance — a worker with `concurrency: 500` must not turn one wake
+ * into thousands of serialized commands. Filling a larger `concurrency` just takes more passes,
+ * which cost one round-trip each and keep the instance responsive in between.
+ */
+const RESERVE_BATCH_CAP = 64
+
+/** Redis' `[field, value, …]` hash reply as a Map. */
+function flatToMap(flat: string[]): Map<string, string> {
+  const map = new Map<string, string>()
+  for (let i = 0; i < flat.length; i += 2) map.set(flat[i]!, flat[i + 1]!)
+  return map
+}
+
 interface Claim {
   job: ReservedJob
   token: string
 }
 
-type ReserveResult =
-  | { kind: 'job'; claim: Claim }
-  | { kind: 'empty'; msToNext: number }
-  | { kind: 'maxed' }
+interface ReserveResult {
+  claims: Claim[]
+  /** Ms until the next delayed job is due (`-1` none, `0` already due). */
+  msToNext: number
+  /** Ms until the nearest cron occurrence (`-1` none, `0` already due). */
+  msToSchedule: number
+  /** `[scheduleId, score, …]` of the schedules due right now. */
+  dueSchedules: string[]
+  /** A concurrency ceiling, not an empty queue, ended the batch. */
+  maxed: boolean
+}
 
 /**
  * Runs jobs for one workflow. A JS-local semaphore (`concurrency`) is the per-worker cap —
- * no Redis round-trip. The loop drains reserve until empty/maxed, then blocks on
- * `BRPOP wf:wake ns:wake <safetyTimeout>` (its own connection); enqueue and every release
- * `LPUSH` those wake lists, so a freed slot or new work re-drives the loop.
+ * no Redis round-trip. Each pass makes exactly one `reserve` call that claims a batch (capped at
+ * `RESERVE_BATCH_CAP`) and reports the delayed/cron timers, then parks one of two ways:
+ *
+ * - **slots free** — `BRPOP wf:wake ns:wake <safetyTimeout>` on its own connection. Enqueue and
+ *   every release `LPUSH` those wake lists, so new work anywhere re-drives the loop.
+ * - **every slot busy** — an in-process wait for a slot to free. Nothing Redis could say is
+ *   actionable while saturated, and the next actionable event is local, so this costs no
+ *   round-trip; a completion re-drives the loop the instant it lands.
  */
 export class Worker {
   private readonly concurrency: number
@@ -42,10 +69,11 @@ export class Worker {
   private readonly redis: QueueRedis
   private readonly wfWake: string
   private readonly nsWake: string
-  private readonly scheduleDueKey: string
 
   private inFlight = 0
   private closing = false
+  private lastStalledScan = 0
+  private wakeSlot?: () => void
   private readonly inProgress = new Set<Promise<void>>()
   private readonly loopPromise: Promise<void>
 
@@ -72,7 +100,6 @@ export class Worker {
     this.blockingRedis = queue.redis.duplicate()
     this.wfWake = `${queue.prefix}:${queue.id}:wake`
     this.nsWake = `${queue.prefix}:ns:${queue.ns.id}:wake`
-    this.scheduleDueKey = `${queue.prefix}:${queue.id}:schedules:due`
 
     this.loopPromise = this.loop()
   }
@@ -80,54 +107,60 @@ export class Worker {
   private async loop(): Promise<void> {
     if (this.blockingRedis.status === 'wait') await this.blockingRedis.connect()
     while (!this.closing) {
-      // Fire any due cron occurrences into waiting before draining — no separate poller; the
-      // tick folds into this same wake loop. Firing kicks `wake`, so the drain below picks
-      // the occurrence up in this iteration.
-      await this.tickSchedules()
-      // Drain: reserve until a slot is unavailable or there is no runnable work. `msToNext`
-      // is the reserve-reported ms until the next delayed job is due, carried out to the block.
-      let msToNext = -1
-      while (!this.closing && this.inFlight < this.concurrency) {
-        const res = await this.reserve()
-        if (res.kind === 'job') {
-          this.start(res.claim)
-          continue
-        }
-        if (res.kind === 'empty') msToNext = res.msToNext
-        break
-      }
+      // One round-trip per pass: claim a batch, promote due delayed jobs, and read both timers.
+      // A locally saturated worker still calls it with `want = 0` — promotion and the cron tick
+      // must keep happening while every slot is busy.
+      const want = Math.min(this.concurrency - this.inFlight, RESERVE_BATCH_CAP)
+      const res = await this.reserve(want)
+      // Start what we claimed even while closing: these jobs hold real locks and slots in Redis,
+      // and dropping them here would strand them until stalled-recovery — on every clean
+      // shutdown. `close` drains `inProgress`, so starting them is what makes the drain honest.
+      for (const claim of res.claims) this.start(claim)
       if (this.closing) break
-      // Due work remained past the promote cap — re-reserve at once to drain the next chunk.
-      if (msToNext === 0) continue
-      // Fold the nearest due schedule into the wake timeout so an idle worker wakes to fire it.
-      const msSchedule = await this.msToNextSchedule()
-      if (msSchedule === 0) continue // a schedule is already due — loop back to fire it now
+
+      // Fire any due cron occurrences into waiting — no separate poller; the tick folds into
+      // this same wake loop. Firing kicks `wake`, so the next pass picks the occurrence up.
+      if (res.dueSchedules.length > 0) {
+        await this.tickSchedules(res.dueSchedules)
+        continue
+      }
+      const saturated = this.inFlight >= this.concurrency
+      // The batch cap, not an empty queue, ended this pass — go straight back for the next chunk.
+      if (!saturated && res.claims.length === want) continue
+      // Due work remained past the promote cap — re-reserve at once to drain the next chunk,
+      // unless a ceiling (not an empty queue) is what stopped us, which would spin.
+      if (!saturated && res.msToNext === 0 && !res.maxed) continue
       // Block until woken (new work / freed slot / enqueued delay), the next delayed job or
       // schedule comes due, or the safety re-poll fires — whichever is sooner. The block is the
       // timer for both delayed jobs and schedules.
-      const nearest = [msToNext, msSchedule].filter((m) => m >= 0)
+      // Only *future* timers count: a `0` here means due work we just decided we cannot take
+      // (capped out), and folding it in would mean `brpop … 0` — which blocks forever, not
+      // "immediately" — or a hot `waitForSlot(0)` spin. Falling back to `safetyTimeout` is what
+      // the pre-batch code did in exactly this state.
+      const nearest = [res.msToNext, res.msToSchedule].filter((m) => m > 0)
       const timeout =
         nearest.length === 0
           ? this.safetyTimeout
           : Math.min(Math.min(...nearest) / 1000, this.safetyTimeout)
-      await this.blockingRedis.brpop(this.wfWake, this.nsWake, timeout)
-      // Wake-loop re-poll is the idle-worker stalled-recovery trigger — no dedicated
-      // poller. The scan is throttled in Lua, so firing every re-poll is cheap.
+      // With every slot busy there is nothing Redis could tell us that we could act on, and the
+      // next thing we *can* act on — a slot freeing — is local. Park on it and skip the round
+      // trip entirely; a completion re-drives the loop the instant it lands.
+      if (saturated) await this.waitForSlot(timeout * 1000)
+      else await this.blockingRedis.brpop(this.wfWake, this.nsWake, timeout)
+      // Wake-loop re-poll is the idle-worker stalled-recovery trigger — no dedicated poller.
       if (!this.closing) void this.recoverStalled()
     }
   }
 
   /**
-   * The thin JS cron tick, folded into the wake loop — no poller. Reads due schedules
-   * (`ZRANGEBYSCORE schedules:due -inf now`), computes each one's `nextRun(now)` via Croner, and
+   * The thin JS cron tick, folded into the wake loop — no poller. `reserve` hands back the due
+   * schedules (`[scheduleId, score, …]`), this computes each one's `nextRun(now)` via Croner and
    * calls the `fireSchedule` CAS script with the score it saw. CAS-on-score = exactly-once across
    * N workers; computing next in JS *before* the call = crash-safe. A backlog after downtime
    * collapses to one fire because `nextRun(now)` jumps forward. Errors are best-effort logged.
    */
-  private async tickSchedules(): Promise<void> {
+  private async tickSchedules(due: string[]): Promise<void> {
     try {
-      const now = Date.now()
-      const due = await this.redis.zrangebyscore(this.scheduleDueKey, '-inf', now, 'WITHSCORES')
       for (let i = 0; i < due.length && !this.closing; i += 2) {
         const scheduleId = due[i]!
         const expectedScore = due[i + 1]!
@@ -153,16 +186,16 @@ export class Worker {
     }
   }
 
-  /** Ms until the nearest schedule is due (`-1` none, `0` already due). Folds into the block. */
-  private async msToNextSchedule(): Promise<number> {
-    const next = await this.redis.zrange(this.scheduleDueKey, 0, 0, 'WITHSCORES')
-    if (next.length === 0) return -1
-    const d = Number(next[1]) - Date.now()
-    return d < 0 ? 0 : d
-  }
-
-  /** Fire the throttled stalled-recovery scan (a no-op in Redis if another scan is in-flight). */
+  /**
+   * Fire the throttled stalled-recovery scan. Redis owns the cross-process gate; the local
+   * timestamp keeps this worker from paying a round-trip per wake to be told so — during a fast
+   * drain that is one saved command every time round the loop. Either way some worker scans
+   * within `stalledInterval`, which is the only guarantee recovery makes.
+   */
   private async recoverStalled(): Promise<void> {
+    const now = Date.now()
+    if (now - this.lastStalledScan < this.stalledInterval) return
+    this.lastStalledScan = now
     try {
       await this.redis.recoverStalled(
         this.queue.prefix,
@@ -175,13 +208,15 @@ export class Worker {
         this.keepFailed,
       )
     } catch (err) {
+      // The scan never happened, so it must not count against the local throttle.
+      this.lastStalledScan = 0
       this.onError(err)
     }
   }
 
-  private async reserve(): Promise<ReserveResult> {
-    const token = randomUUID()
-    const res = await this.redis.reserve(
+  /** Claim up to `want` jobs (0 = report only) and read back both wake timers, in one call. */
+  private async reserve(want: number): Promise<ReserveResult> {
+    const [jobs, msToNext, msToSchedule, dueSchedules, maxed] = await this.redis.reserve(
       this.queue.prefix,
       this.queue.id,
       this.queue.ns.id,
@@ -189,20 +224,27 @@ export class Worker {
       this.queue.concurrency,
       this.queue.groupConcurrency,
       this.lockMs,
-      token,
+      randomUUID(),
       this.promoteBatchSize,
+      want,
     )
-    if (res[0] === 'maxed') return { kind: 'maxed' }
-    if (res[0] === 'empty') return { kind: 'empty', msToNext: Number(res[1]) }
-    const [, id, groupId, data, attempts, priority] = res as string[]
-    const job: ReservedJob = Object.freeze({
-      id: id!,
-      groupId: groupId!,
-      data: data!,
-      attemptsMade: Number(attempts),
-      priority: Number(priority),
-    })
-    return { kind: 'job', claim: { job, token } }
+    return {
+      claims: jobs.map(([id, groupId, data, attempts, priority, token, steps]) => ({
+        job: Object.freeze({
+          id,
+          groupId,
+          data,
+          attemptsMade: Number(attempts),
+          priority: Number(priority),
+          steps: flatToMap(steps),
+        }) as ReservedJob,
+        token,
+      })),
+      msToNext: Number(msToNext),
+      msToSchedule: Number(msToSchedule),
+      dueSchedules,
+      maxed: maxed === 1,
+    }
   }
 
   private start(claim: Claim): void {
@@ -210,8 +252,28 @@ export class Worker {
     const promise = this.process(claim).finally(() => {
       this.inFlight--
       this.inProgress.delete(promise)
+      this.wakeSlot?.()
     })
     this.inProgress.add(promise)
+  }
+
+  /**
+   * Park until a slot frees locally (or `timeoutMs` elapses) — the zero-round-trip block. There
+   * is only ever one waiter, the single wake loop, so this is one nullable callback rather than
+   * a waiter list.
+   */
+  private async waitForSlot(timeoutMs: number): Promise<void> {
+    const { promise, resolve } = Promise.withResolvers<void>()
+    const timer = setTimeout(resolve, timeoutMs)
+    this.wakeSlot = () => {
+      clearTimeout(timer)
+      resolve()
+    }
+    try {
+      await promise
+    } finally {
+      this.wakeSlot = undefined
+    }
   }
 
   private async process(claim: Claim): Promise<void> {
@@ -314,7 +376,8 @@ export class Worker {
   /** Stop accepting work, drain in-flight jobs, then quit the blocking connection. */
   async close(): Promise<void> {
     this.closing = true
-    // Unblock a pending BRPOP so the loop can observe `closing`.
+    // Unblock the loop so it can observe `closing`, whichever way it is parked.
+    this.wakeSlot?.()
     await this.redis.lpush(this.wfWake, '1')
     await this.redis.ltrim(this.wfWake, 0, 0)
     await this.loopPromise

--- a/src/step.ts
+++ b/src/step.ts
@@ -23,6 +23,7 @@ export class WorkflowStep {
   private signal
   private stepPromises
   private logger
+  private memo
 
   constructor(opts: {
     queue: WorkflowQueueInternal
@@ -31,6 +32,8 @@ export class WorkflowStep {
     stepNamePrefix?: string
     signal: AbortSignal
     stepPromises: Set<Promise<any>>
+    /** The job's persisted step data, shipped with the claim — the memo's initial contents. */
+    memo: Map<string, string>
   }) {
     this.queue = opts.queue
     this.workflowJobId = opts.workflowJobId
@@ -39,6 +42,7 @@ export class WorkflowStep {
     this.signal = opts.signal
     this.stepPromises = opts.stepPromises
     this.logger = opts.queue.logger
+    this.memo = opts.memo
   }
 
   private addNamePrefix(name: string) {
@@ -50,7 +54,7 @@ export class WorkflowStep {
 
     // Memoize on completion only: a stored `result` field means the step finished on a prior
     // attempt, so a job-level retry replays it from cache and only re-runs the failed step.
-    const stepData = await this.getStepData('do', name)
+    const stepData = this.getStepData('do', name)
     if (stepData && 'result' in stepData) {
       this.logger?.debug?.(
         `[${this.workflowId}/${this.workflowJobId}] Step '${name}' already completed, returning cached result`,
@@ -80,6 +84,7 @@ export class WorkflowStep {
             stepNamePrefix: name,
             signal: this.signal,
             stepPromises: this.stepPromises,
+            memo: this.memo,
           }),
           span,
         })
@@ -99,7 +104,7 @@ export class WorkflowStep {
   async wait(stepName: string, durationMs: number) {
     const name = this.addNamePrefix(stepName)
 
-    const existingStepData = await this.getStepData('wait', name)
+    const existingStepData = this.getStepData('wait', name)
 
     const now = Date.now()
     const stepData = existingStepData ?? {
@@ -138,9 +143,14 @@ export class WorkflowStep {
     return this.wait(stepName, durationMs)
   }
 
-  private async getStepData<T extends WorkflowStepData['type']>(type: T, stepName: string) {
-    const raw = await this.queue.getStepData(this.workflowJobId, stepName)
-    if (raw === null) return
+  /**
+   * Read a step's persisted data. The memo is seeded from the step hash that came back with the
+   * claim and kept in step with every write, so this is always local — the durability round-trip
+   * happens on write, never on read.
+   */
+  private getStepData<T extends WorkflowStepData['type']>(type: T, stepName: string) {
+    const raw = this.memo.get(stepName)
+    if (raw === undefined) return
 
     const stepData = deserialize<WorkflowStepData>(raw)
     if (stepData.type !== type)
@@ -151,6 +161,8 @@ export class WorkflowStep {
 
   /** Per-field superjson persist — a single atomic `HSET` on the job's `:steps` hash. */
   private async updateStepData(stepName: string, data: WorkflowStepData) {
-    await this.queue.setStepData(this.workflowJobId, stepName, serialize(data))
+    const raw = serialize(data)
+    await this.queue.setStepData(this.workflowJobId, stepName, raw)
+    this.memo.set(stepName, raw)
   }
 }

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -218,6 +218,7 @@ export class Workflow<RunInput, Input, Output> {
                   workflowId: this.id,
                   signal: ctx.signal,
                   stepPromises,
+                  memo: new Map(job.steps),
                 }),
                 span,
               })

--- a/tests/fixtures/worker-process.ts
+++ b/tests/fixtures/worker-process.ts
@@ -1,0 +1,35 @@
+/**
+ * A worker in its own OS process, for `tests/multi-process.test.ts`.
+ *
+ * Config comes in on argv. Every job bumps a shared Redis counter, so the parent can prove
+ * exactly-once execution across processes without any IPC bookkeeping. The parent kills us when
+ * the assertion is done.
+ */
+
+import process from 'node:process'
+import { createRedis, WorkflowNamespace } from '../../src'
+
+const [port, prefix, nsId, wfId, concurrency] = process.argv.slice(2)
+const host = 'localhost'
+
+const counter = await createRedis({ host, port: Number(port) })
+const ns = new WorkflowNamespace({
+  id: nsId!,
+  prefix: prefix!,
+  redis: await createRedis({ host, port: Number(port) }),
+  autoClose: false,
+})
+
+const workflow = ns.createWorkflow({
+  id: wfId!,
+  run: async ({ step }) => {
+    // Inside a step: a replay would return the cached result without re-incrementing, so the
+    // counter measures real executions, not attempts.
+    await step.do('count', async () => counter.incr(`${prefix}:runs`))
+    return 'ok'
+  },
+})
+
+await workflow.work({ concurrency: Number(concurrency), backoff: () => 0 })
+
+process.send?.('ready')

--- a/tests/multi-process.test.ts
+++ b/tests/multi-process.test.ts
@@ -1,0 +1,88 @@
+/**
+ * The acceptance criterion the in-process tests structurally cannot cover: several workers in
+ * separate OS processes* against one Redis.
+ *
+ * This matters specifically for the perf rework, which moved three decisions out of Redis and
+ * into each worker's own heap — the batch claim, the local slot park, and the local
+ * stalled-scan throttle. Every one of those is invisible to peers by construction, so only real
+ * processes can show that the Redis-side invariants (exactly-once, the caps, recovery of a
+ * killed* process's claims) still hold between them.
+ */
+
+import type { Redis } from 'ioredis'
+import type { ChildProcess } from 'node:child_process'
+import { fork } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { afterEach, beforeAll, expect, test } from 'vitest'
+import { createRedis, WorkflowNamespace } from '../src'
+
+const FIXTURE = fileURLToPath(new URL('fixtures/worker-process.ts', import.meta.url))
+
+let redis: Redis
+beforeAll(async () => {
+  redis = await createRedis({ host: 'localhost', port: Number(process.env.REDIS_PORT) })
+})
+
+const children: ChildProcess[] = []
+afterEach(() => {
+  for (const child of children.splice(0)) child.kill('SIGKILL')
+})
+
+/** Fork a worker process and resolve once it has started draining. */
+async function spawnWorker(opts: {
+  prefix: string
+  nsId: string
+  wfId: string
+  concurrency: number
+}) {
+  const child = fork(
+    FIXTURE,
+    [String(process.env.REDIS_PORT), opts.prefix, opts.nsId, opts.wfId, String(opts.concurrency)],
+    { execArgv: ['--import', 'tsx'], stdio: ['ignore', 'inherit', 'inherit', 'ipc'] },
+  )
+  children.push(child)
+  await new Promise<void>((resolve, reject) => {
+    child.once('message', () => resolve())
+    child.once('error', reject)
+    child.once('exit', (code) => reject(new Error(`worker exited early with code ${code}`)))
+  })
+  return child
+}
+
+test('four worker processes drain a backlog exactly once each', async () => {
+  const prefix = randomUUID()
+  const nsId = randomUUID()
+  const wfId = randomUUID()
+  const JOBS = 120
+
+  const ns = new WorkflowNamespace({
+    id: nsId,
+    prefix,
+    redis: await createRedis({ host: 'localhost', port: Number(process.env.REDIS_PORT) }),
+    autoClose: false,
+  })
+  const workflow = ns.createWorkflow({ id: wfId, run: async () => 'ok' })
+
+  try {
+    // Enqueue the whole backlog first, so every worker starts against a full queue and they all
+    // race to batch-claim from it — the case where a greedy batch could double-claim.
+    const jobs = await Promise.all(
+      Array.from({ length: JOBS }, async () => workflow.run(undefined)),
+    )
+
+    await Promise.all(
+      Array.from({ length: 4 }, async () => spawnWorker({ prefix, nsId, wfId, concurrency: 8 })),
+    )
+
+    await Promise.all(jobs.map(async (job) => job.wait(60_000)))
+
+    // Exactly-once across processes: one increment per job, no more.
+    expect(await redis.get(`${prefix}:runs`)).toBe(String(JOBS))
+    expect(await redis.zcard(`${prefix}:${wfId}:active`)).toBe(0)
+    expect(await redis.scard(`${prefix}:ns:${nsId}:active`)).toBe(0)
+  } finally {
+    await ns.close()
+  }
+}, 90_000)

--- a/tests/queue.test.ts
+++ b/tests/queue.test.ts
@@ -541,25 +541,31 @@ test('add() rejects an out-of-range or non-integer priority', async () => {
 // Mutable step data (ticket 05)
 // ---------------------------------------------------------------------------
 
-test('setStepData/getStepData round-trips an opaque string; null on miss', async () => {
-  const ns = new Namespace({ id: randomUUID(), redis: await connect(), prefix: randomUUID() })
-  const queue = ns.queue({ id: randomUUID() })
+test('setStepData writes an opaque string to the job step hash', async () => {
+  const prefix = randomUUID()
+  const conn = await connect()
+  const ns = new Namespace({ id: randomUUID(), redis: conn, prefix })
+  const wfId = randomUUID()
+  const queue = ns.queue({ id: wfId })
 
   try {
     const jobId = randomUUID()
-    expect(await queue.getStepData(jobId, 'step-a')).toBeNull() // never written
-
+    const stepsKey = `${prefix}:${wfId}:j:${jobId}:steps`
+    expect(await conn.hget(stepsKey, 'step-a')).toBeNull() // never written
     await queue.setStepData(jobId, 'step-a', 'opaque \n{"x":1}')
-    expect(await queue.getStepData(jobId, 'step-a')).toBe('opaque \n{"x":1}')
-    expect(await queue.getStepData(jobId, 'step-b')).toBeNull() // distinct field still missing
+    expect(await conn.hget(stepsKey, 'step-a')).toBe('opaque \n{"x":1}')
+    expect(await conn.hget(stepsKey, 'step-b')).toBeNull() // distinct field still missing
   } finally {
     await ns.close()
   }
 })
 
 test('parallel setStepData on distinct steps both persist (no lost update)', async () => {
-  const ns = new Namespace({ id: randomUUID(), redis: await connect(), prefix: randomUUID() })
-  const queue = ns.queue({ id: randomUUID() })
+  const prefix = randomUUID()
+  const conn = await connect()
+  const ns = new Namespace({ id: randomUUID(), redis: conn, prefix })
+  const wfId = randomUUID()
+  const queue = ns.queue({ id: wfId })
 
   try {
     const jobId = randomUUID()
@@ -567,8 +573,10 @@ test('parallel setStepData on distinct steps both persist (no lost update)', asy
       queue.setStepData(jobId, 'a', 'value-a'),
       queue.setStepData(jobId, 'b', 'value-b'),
     ])
-    expect(await queue.getStepData(jobId, 'a')).toBe('value-a')
-    expect(await queue.getStepData(jobId, 'b')).toBe('value-b')
+    expect(await conn.hgetall(`${prefix}:${wfId}:j:${jobId}:steps`)).toEqual({
+      a: 'value-a',
+      b: 'value-b',
+    })
   } finally {
     await ns.close()
   }
@@ -933,11 +941,17 @@ test('keepFailed count-trims the failed ZSET and DELs evicted job hashes', async
 
   try {
     // Fail 4 jobs one at a time (sequenced via wait) ⇒ strictly increasing `finishedOn`.
+    // `finishedOn` is the retention score and is only millisecond-granular, so two failures
+    // landing in the same millisecond would tie and be evicted in member (uuid) order rather
+    // than the order they finished — which is what this test is asserting. `wait()` now returns
+    // as soon as the notification lands rather than after a second read, so the loop can and
+    // does close that gap on a fast box: step past the millisecond to keep the premise true.
     const ids: string[] = []
     for (let i = 0; i < 4; i++) {
       const { id } = await queue.add(`j${i}`)
       ids.push(id)
       await queue.wait(id).catch(() => {})
+      await sleep(2)
     }
 
     const failedKey = `${prefix}:${wfId}:failed`
@@ -1490,6 +1504,264 @@ test('onError is invoked when a worker-internal operation throws', async () => {
     expect((error as Error).message).toBe('scan failed')
   } finally {
     vi.restoreAllMocks()
+    await ns.close()
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Batch reserve + local slot parking (perf rework)
+//
+// `reserve` now claims a BATCH of jobs in one atomic script and a saturated worker parks on an
+// in-process signal instead of BRPOP. Both move decisions that used to be one-per-round-trip
+// into places where a bug is invisible from the outside — these pin the invariants that keep
+// them honest, including across workers that do not share a JS heap.
+// ---------------------------------------------------------------------------
+
+test('batch reserve never exceeds the group cap, however many slots the worker offers', async () => {
+  const prefix = randomUUID()
+  const nsId = randomUUID()
+  const wfId = randomUUID()
+  const ns = new Namespace({ id: nsId, redis: await connect(), prefix })
+  // One group, cap 1: a single batch could trivially claim all 8 at once if the Lua loop failed
+  // to re-evaluate the group's `ready` membership between claims.
+  const queue = ns.queue({ id: wfId, groupConcurrency: 1 })
+  const tracker = makeTracker()
+  const ran = vi.fn()
+
+  try {
+    queue.worker(
+      async (job) => {
+        tracker.enter()
+        await sleep(5)
+        tracker.exit()
+        ran(job.data)
+        return 'ok'
+      },
+      { concurrency: 20 },
+    )
+
+    for (let i = 0; i < 8; i++) await queue.add(`job-${i}`, { groupId: 'g' })
+
+    await vi.waitFor(() => {
+      expect(ran).toHaveBeenCalledTimes(8)
+    })
+    expect(tracker.max).toBe(1)
+    await assertDrained(prefix, [wfId], nsId)
+  } finally {
+    await ns.close()
+  }
+})
+
+test('batch reserve respects the namespace cap across workers on separate connections', async () => {
+  const prefix = randomUUID()
+  const nsId = randomUUID()
+  const wfId = randomUUID()
+  const NS_CAP = 2
+
+  // Two Namespace instances on two connections = two independent JS heaps' worth of worker
+  // state, exactly like two processes. Only Redis can hold the cap between them.
+  const nsA = new Namespace({ id: nsId, concurrency: NS_CAP, redis: await connect(), prefix })
+  const nsB = new Namespace({ id: nsId, concurrency: NS_CAP, redis: await connect(), prefix })
+  const queueA = nsA.queue({ id: wfId })
+  const queueB = nsB.queue({ id: wfId })
+  const tracker = makeTracker()
+  const ran = vi.fn()
+
+  try {
+    for (const queue of [queueA, queueB]) {
+      queue.worker(
+        async (job) => {
+          tracker.enter()
+          await sleep(10)
+          tracker.exit()
+          ran(job.data)
+          return 'ok'
+        },
+        // Each worker offers far more slots than the namespace allows, so an uncapped batch
+        // would blow straight through NS_CAP.
+        { concurrency: 20 },
+      )
+    }
+
+    for (let i = 0; i < 12; i++) await queueA.add(`job-${i}`)
+
+    await vi.waitFor(() => {
+      expect(ran).toHaveBeenCalledTimes(12)
+    })
+    expect(tracker.max).toBeLessThanOrEqual(NS_CAP)
+    await assertDrained(prefix, [wfId], nsId)
+  } finally {
+    await Promise.all([nsA.close(), nsB.close()])
+  }
+})
+
+test('every job in one batch gets a distinct claim token, so each one commits', async () => {
+  const prefix = randomUUID()
+  const nsId = randomUUID()
+  const wfId = randomUUID()
+  const ns = new Namespace({ id: nsId, redis: await connect(), prefix })
+  const queue = ns.queue({ id: wfId })
+
+  try {
+    // Tokens are derived in-script as `<uuid>:<n>`. If two jobs in a batch shared a token, the
+    // token guard on `complete` would silently no-op one of them and it would hang here.
+    queue.worker(() => 'ok', { concurrency: 20 })
+
+    const ids: string[] = []
+    for (let i = 0; i < 20; i++) {
+      const job = await queue.add(`job-${i}`)
+      ids.push(job.id)
+    }
+
+    const results = await Promise.all(ids.map(async (id) => queue.wait(id, { timeoutMs: 10_000 })))
+    expect(results).toHaveLength(20)
+    await assertDrained(prefix, [wfId], nsId)
+  } finally {
+    await ns.close()
+  }
+})
+
+test('a worker held off by a cap another process owns still re-polls and recovers it', async () => {
+  const prefix = randomUUID()
+  const nsId = randomUUID()
+  const wfId = randomUUID()
+  const ns = new Namespace({ id: nsId, redis: await connect(), prefix })
+  // Workflow cap 1: while the dead claim below is held, our worker can never claim anything.
+  const queue = ns.queue({ id: wfId, concurrency: 1 })
+  const ran = vi.fn()
+
+  try {
+    // A claim held by a process that then died: reserved directly, never heartbeated, never
+    // completed. Nothing will ever LPUSH a wake on its behalf.
+    const stuck = await queue.add('stuck')
+    const noNsCap = Number.MAX_SAFE_INTEGER
+    const claimed = await ns.redis.reserve(
+      prefix,
+      wfId,
+      nsId,
+      noNsCap,
+      1,
+      1,
+      150,
+      randomUUID(),
+      500,
+      1,
+    )
+    const [claimedJobs] = claimed
+    expect(claimedJobs).toHaveLength(1)
+
+    // More due delayed jobs than the promote cap, so `reserve` keeps reporting msToNext = 0
+    // ("work is due right now") while the cap says we cannot have it. That pair used to compute
+    // a BRPOP timeout of 0 — which Redis reads as *block forever*, not *don't block* — so the
+    // worker parked permanently and never ran the stalled scan that frees the dead claim.
+    for (let i = 0; i < 3; i++) await queue.add(`delayed-${i}`, { runIn: 40 })
+    await sleep(120)
+
+    queue.worker(() => 'ok', {
+      concurrency: 5,
+      promoteBatchSize: 1,
+      lockMs: 150,
+      stalledInterval: 100,
+      maxStalledCount: 10,
+      safetyTimeout: 0.2,
+      backoff: () => 0,
+      onFailed: () => {
+        ran('failed')
+      },
+    })
+
+    // All four jobs — the recovered one and the three delayed — must drain.
+    await vi.waitFor(
+      async () => {
+        expect(await redis.zcard(`${prefix}:${wfId}:delayed`)).toBe(0)
+        expect(await redis.exists(`${prefix}:${wfId}:j:${stuck.id}`)).toBe(0)
+      },
+      { timeout: 15_000, interval: 100 },
+    )
+    await assertDrained(prefix, [wfId], nsId)
+  } finally {
+    await ns.close()
+  }
+})
+
+test('close() during an in-flight batch reserve strands nothing', async () => {
+  // The loop claims up to `concurrency` jobs in one call. If it dropped that batch on seeing
+  // `closing`, those jobs would sit `active` — locked, slot-consuming, invisible — until
+  // stalled-recovery, on every clean shutdown. Racing close() against the reserve pins that:
+  // 0ms lands inside the first round-trip, 2ms after it, so both sides of the window are hit.
+  for (const delayMs of [0, 2]) {
+    const prefix = randomUUID()
+    const nsId = randomUUID()
+    const wfId = randomUUID()
+    const ns = new Namespace({ id: nsId, redis: await connect(), prefix })
+    const queue = ns.queue({ id: wfId })
+
+    try {
+      for (let i = 0; i < 16; i++) await queue.add(`job-${i}`)
+
+      const worker = queue.worker(() => 'ok', { concurrency: 16 })
+      // Land close() at varying points across the first reserve round-trip.
+      await sleep(delayMs)
+      await worker.close()
+
+      // Whatever it claimed, it finished: nothing may be left holding a slot or a lock.
+      const lockKeys = await redis.keys(`${prefix}:${wfId}:j:*:lock`)
+      expect({
+        wfActive: await redis.zcard(`${prefix}:${wfId}:active`),
+        nsActive: await redis.scard(`${prefix}:ns:${nsId}:active`),
+        locks: lockKeys.length,
+      }).toEqual({ wfActive: 0, nsActive: 0, locks: 0 })
+    } finally {
+      await ns.close()
+    }
+  }
+})
+
+test('a saturated worker still fires a due cron schedule (it parks locally, not blindly)', async () => {
+  const prefix = randomUUID()
+  const nsId = randomUUID()
+  const wfId = randomUUID()
+  const ns = new Namespace({ id: nsId, redis: await connect(), prefix })
+  const queue = ns.queue({ id: wfId })
+  const release = makeGate()
+  const seen: string[] = []
+
+  try {
+    // Concurrency 1, and the only slot is occupied by a job that will not finish until we say
+    // so. A saturated worker parks on an in-process signal now — the cron tick must still run.
+    queue.worker(
+      async (job) => {
+        seen.push(job.data)
+        if (job.data === 'blocker') await release.wait()
+        return 'ok'
+      },
+      { concurrency: 1, safetyTimeout: 0.2 },
+    )
+    await queue.add('blocker')
+    await vi.waitFor(() => {
+      expect(seen).toContain('blocker')
+    })
+
+    await queue.upsertSchedule('tick', { pattern: '* * * * * *', data: 'from-cron' })
+
+    // The occurrence must reach `waiting` while the worker is still saturated.
+    await vi.waitFor(
+      async () => {
+        expect(await redis.zcard(`${prefix}:${wfId}:ready`)).toBeGreaterThan(0)
+      },
+      { timeout: 10_000, interval: 100 },
+    )
+
+    release.open()
+    await vi.waitFor(
+      () => {
+        expect(seen).toContain('from-cron')
+      },
+      { timeout: 10_000, interval: 100 },
+    )
+  } finally {
+    release.open()
+    await queue.removeSchedule('tick')
     await ns.close()
   }
 })

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -2,6 +2,7 @@ import type { StandardSchemaV1 } from '@standard-schema/spec'
 import { randomUUID } from 'node:crypto'
 import { sleep } from '@antfu/utils'
 import { type } from 'arktype'
+import { stringify } from 'superjson'
 import { beforeAll, describe, expect, test, vi } from 'vitest'
 import { createRedis, ResultExpiredError, TimeoutError, WorkflowNamespace } from '../src'
 
@@ -554,4 +555,82 @@ test('retired surface is absent (keepCompleted / step retry / repeat / removeRep
   })
   // The retired options are ignored, not honored: the job still runs once and completes.
   await expect(job.wait()).resolves.toBe(1)
+})
+
+// ---------------------------------------------------------------------------
+// Step memo prefetch + `done` publish payload (perf rework)
+//
+// Step data now rides along with the claim instead of being read per step, and the `done`
+// publish carries the result record instead of a bare wake-up. Both are cross-process wire
+// contracts, so they need to hold for a worker that never saw the earlier attempt and for a
+// peer still running the older shape.
+// ---------------------------------------------------------------------------
+
+describe('step memo prefetch', () => {
+  test('a retry picked up by a different worker still replays completed steps', async () => {
+    // The memo is seeded from the step hash that `reserve` ships with the claim. Two workers on
+    // separate connections means the retry can land on a worker whose heap never held this
+    // job's step data — the prefetch is the only thing that can carry it across.
+    // `namespace()` shares the suite-wide connection, so it must not be closed here.
+    const ns = namespace()
+    const stepA = vi.fn(async () => 'a')
+    const stepB = vi.fn(async () => 'b')
+    let attempts = 0
+
+    const workflow = ns.createWorkflow({
+      id: randomUUID(),
+      run: async ({ step }) => {
+        await step.do('a', stepA)
+        attempts++
+        if (attempts === 1) throw new Error('fail after a')
+        await step.do('b', stepB)
+        return 'done'
+      },
+    })
+
+    await workflow.work({ concurrency: 5, maxAttempts: 5, backoff: () => 0 })
+    await workflow.work({ concurrency: 5, maxAttempts: 5, backoff: () => 0 })
+
+    const job = await workflow.run(undefined, { maxAttempts: 5 })
+    await expect(job.wait(15_000)).resolves.toBe('done')
+
+    // Step 'a' completed on attempt 1; the replay must return its cached result, not re-run it.
+    expect(stepA).toHaveBeenCalledOnce()
+    expect(stepB).toHaveBeenCalledOnce()
+    expect(attempts).toBe(2)
+  })
+})
+
+test('a bare "1" done publish (an older peer) still resolves via the result key', async () => {
+  // The publish payload is a wire format shared with other processes. During a rolling deploy a
+  // peer running the previous build publishes `"1"` with the record only in the result key —
+  // that must still resolve, not be parsed as a result.
+  const redis = await connect()
+  const prefix = randomUUID()
+  const wfId = randomUUID()
+  const ns = new WorkflowNamespace({
+    id: randomUUID(),
+    redis,
+    prefix,
+    logger: console,
+    autoClose: false,
+  })
+  const workflow = ns.createWorkflow({ id: wfId, run: async () => 'unused' })
+
+  try {
+    const job = await workflow.run(undefined)
+    const waiting = job.wait(10_000)
+
+    // Write the record the way the old code did, then ring the old doorbell.
+    const resultKey = `${prefix}:${wfId}:result:${job.id}`
+    const channel = `${prefix}:${wfId}:done:${job.id}`
+    const record = { state: 'completed', value: stringify('legacy') }
+    await redis.set(resultKey, JSON.stringify(record), 'EX', 60)
+    const pump = setInterval(() => void redis.publish(channel, '1'), 20)
+
+    await expect(waiting).resolves.toBe('legacy')
+    clearInterval(pump)
+  } finally {
+    await ns.close()
+  }
 })


### PR DESCRIPTION
A CPU profile of a concurrency-50 drain showed the worker **69% idle** — round-trip bound, not CPU bound. So this is not micro-optimisation; every change deletes a Redis round-trip from a hot path. Adds an e2e benchmark first so the numbers are measured rather than asserted.

## Results

Adjacent runs on the same (loaded) machine, best of three:

| scenario | before | after |
|---|---|---|
| drain 1 worker c=1 | 2 543 | **3 303** ops/s (+30%) |
| drain 1 worker c=50 | 8 986 | **15 677** ops/s (+74%) |
| drain c=50, 3 steps | 5 536 | **8 319** ops/s (+50%) |
| drain c=50, 10 groups | 8 716 | **14 066** ops/s (+61%) |
| run → wait round trip | 0.85 ms | **0.46 ms** (-46%) |
| enqueue | 8 315 / 37 263 | 7 966 / 31 872 |

The enqueue path is untouched, so it scores identically — that was the control. Any run where it moved was a run where the machine, not the code, had changed.

## What changed

**One `reserve` per wake, claiming a batch.** It used to take four commands to get round the loop: a schedule poll, a ms-to-next-schedule poll, one `reserve` per job claimed, and a stalled scan. Now `reserve` claims a batch atomically and returns both timers and the due-schedule list with it. The schedule polls were pure overhead for the common case of a workflow with no cron schedules at all.

**A saturated worker parks locally.** It was doing a network round-trip to be told that a slot *it owns* had freed — and that hop sat directly between one job finishing and the next being claimed. It now waits on an in-process signal. When slots are free it still `BRPOP`s, because then the interesting event genuinely is remote.

**Step memo ships with the claim.** Every `step.do` began with an `HGET` that, on a first attempt, is a guaranteed miss. The claim makes the worker the sole writer of that hash, so `HGETALL` inside the reserve script is an exact snapshot and step *reads* now cost nothing. Writes still persist before a step counts as done.

**The `done` publish carries the result.** It was a content-free doorbell: the waiter got woken, then had to go ask what happened. `wait()` goes from four blocking round-trips to two.

**Local throttle on the stalled scan**, which Redis was rejecting via its gate anyway — the worker was paying a round-trip to find out.

## Notes for review

- **`RESERVE_BATCH_CAP = 64`** bounds the batch. Redis runs Lua single-threaded, so an unbounded `concurrency` would turn one wake into thousands of serialized commands and pause *every* client on the instance. Filling a larger concurrency just takes more passes.
- **`resolvePublished`'s non-record fallback is load-bearing**, not defensive coding. During a rolling deploy a peer on the previous build publishes `"1"`; parsing that as a result would silently hand the caller an empty string.
- **`Queue.getStepData` is deleted.** Not a breaking change — `src/index.ts` doesn't export `Queue`.
- **Namespace and workflow caps are client-side config**, passed into the Lua on every reserve rather than stored in Redis. Pre-existing, not from this PR, but it means a process configured with a looser cap silently widens it for the whole fleet. Surfaced while writing the multi-process tests.
- `keepFailed`'s retention score is millisecond-granular, so same-ms failures evict in uuid order rather than finish order. Always true; removing a round-trip from `wait()` just made it reachable, and one existing test was relying on the latency. Test premise fixed, library behaviour unchanged.

## Tests

75 passing. New coverage targets what the batch and the local park could break silently: group and namespace caps under batch claiming, distinct claim tokens within one batch, `close()` racing an in-flight batch, a worker held off by a cap a dead peer owns, a saturated worker still firing cron, a retry replaying steps on a *different* worker, the legacy publish shape, and four real OS processes draining a backlog exactly once.