### PR TITLE
feat(job)!: stream typed lifecycle and progress events

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,9 +198,3 @@ Spans are emitted for producers, workers and each step via the global OpenTeleme
 
 - https://x.com/imsh4yy/status/1984073526605967785?s=46
 
-## Breaking changes
-
-- `groupId` is no longer exposed on the public job handle. Group ordering options still work.
-- Do not rolling-deploy this version alongside an older release. Progress records use the existing
-  per-job completion channel, and an older peer can mistake one for a completed job with empty
-  output. Stop every old producer and worker, deploy the new version, then restart them together.

--- a/README.md
+++ b/README.md
@@ -197,4 +197,3 @@ Spans are emitted for producers, workers and each step via the global OpenTeleme
 ## Inspiration
 
 - https://x.com/imsh4yy/status/1984073526605967785?s=46
-

--- a/README.md
+++ b/README.md
@@ -61,6 +61,55 @@ const result = await job.wait()
 console.log(result.engagementLevel)
 ```
 
+### Watching jobs
+
+Declare a Standard Schema for progress, then emit its input type from any step. Watchers receive
+the validated output type on the same stream as lifecycle and terminal events.
+
+```ts
+const exportPdf = namespace.createWorkflow({
+  id: 'export-pdf',
+  schema: z.object({ reportId: z.string() }),
+  progressSchema: z.object({
+    label: z.string(),
+    done: z.number(),
+    total: z.number(),
+  }),
+  async run({ input, step }) {
+    const rows = await step.do('fetch rows', async ({ step: nestedStep }) => {
+      await nestedStep.progress({ label: 'Fetching rows', done: 0, total: 0 })
+      return loadRows(input.reportId)
+    })
+    await step.progress({ label: 'Rendering', done: 0, total: rows.length })
+    return renderPdf(rows)
+  },
+})
+
+const { job, events } = await exportPdf.runAndWatch({ reportId: '1' })
+for await (const event of events) {
+  if (event.type === 'progress') console.log(event.data.label)
+  if (event.type === 'completed') console.log(event.output)
+}
+```
+
+Events published before `watch()` attaches are lost. Lifecycle and progress events are not
+persisted, and the watcher reads no progress snapshot. Use `runAndWatch()` when the first event
+matters because it subscribes before enqueueing. To attach from another request or process, build
+a handle from the known id:
+
+```ts
+const job = await exportPdf.getJob(jobId)
+const events = await job.watch({ signal: request.signal })
+```
+
+`watch()` subscribes before it resolves and buffers until iteration starts. Breaking out of the
+loop unsubscribes. A retry emits another `started` event, while `failed` is terminal. A completed
+job still yields its stored terminal result until the configured result TTL expires.
+
+The library does not derive a percentage, ETA, or step count because workflows have no declared
+step list. If a workflow knows a total, include it in its progress payload as above. Without a
+`progressSchema`, `step.progress()` is a type error and the `progress` event arm is absent.
+
 ### Steps
 
 - `step.do(name, fn)` — run once, memoize the result. Replayed from Redis on a retry.
@@ -148,3 +197,10 @@ Spans are emitted for producers, workers and each step via the global OpenTeleme
 ## Inspiration
 
 - https://x.com/imsh4yy/status/1984073526605967785?s=46
+
+## Breaking changes
+
+- `groupId` is no longer exposed on the public job handle. Group ordering options still work.
+- Do not rolling-deploy this version alongside an older release. Progress records use the existing
+  per-job completion channel, and an older peer can mistake one for a completed job with empty
+  output. Stop every old producer and worker, deploy the new version, then restart them together.

--- a/src/job.ts
+++ b/src/job.ts
@@ -1,17 +1,66 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
 import type { Queue } from './queue'
+import type { QueueEvent } from './queue/types'
 import { deserialize } from './serializer'
 
-export class WorkflowJob<Output> {
+export type WorkflowEvent<Output, Progress = never> =
+  | { type: 'started'; attempt: number }
+  | ([Progress] extends [never] ? never : { type: 'progress'; data: Progress })
+  | { type: 'completed'; output: Output }
+  | { type: 'failed'; error: Error }
+
+export class WorkflowJob<Output, Progress = never> {
   private queue
   private jobId
-  groupId
+  private progressSchema
+  private readonly watchBeforeEnqueue
   id
 
-  constructor(opts: { queue: Queue; jobId: string; groupId: string }) {
+  constructor(opts: {
+    queue: Queue
+    jobId: string
+    progressSchema?: StandardSchemaV1<unknown, Progress>
+    watchBeforeEnqueue?: boolean
+  }) {
     this.queue = opts.queue
     this.jobId = opts.jobId
-    this.groupId = opts.groupId
+    this.progressSchema = opts.progressSchema
+    this.watchBeforeEnqueue = opts.watchBeforeEnqueue
     this.id = opts.jobId
+  }
+
+  /** Stream events published after this watcher attaches. */
+  async watch(opts?: {
+    signal?: AbortSignal
+  }): Promise<ReadableStream<WorkflowEvent<Output, Progress>>> {
+    const events = await this.queue.watch(this.jobId, {
+      ...opts,
+      allowMissing: this.watchBeforeEnqueue,
+    })
+    const progressSchema = this.progressSchema
+    const jobId = this.jobId
+    return events.pipeThrough(
+      new TransformStream<QueueEvent, WorkflowEvent<Output, Progress>>({
+        async transform(event, controller) {
+          if (event.type === 'completed') {
+            controller.enqueue({ type: 'completed', output: deserialize<Output>(event.output) })
+          } else if (event.type === 'progress') {
+            if (!progressSchema) throw new Error(`Job ${jobId} emitted undeclared progress`)
+            const parsed = await progressSchema['~standard'].validate(deserialize(event.data))
+            if (parsed.issues)
+              throw new Error(`Invalid workflow progress for job ${jobId}`, {
+                cause: parsed.issues,
+              })
+            controller.enqueue({ type: 'progress', data: parsed.value } as WorkflowEvent<
+              Output,
+              Progress
+            >)
+          } else {
+            controller.enqueue(event)
+          }
+        },
+      }),
+    )
   }
 
   /**

--- a/src/queue/namespace.ts
+++ b/src/queue/namespace.ts
@@ -19,6 +19,7 @@ export class Namespace {
   private readonly subscriber: Redis
   private readonly subscriberReady: Promise<unknown>
   private readonly channelListeners = new Map<string, Set<(message: string) => void>>()
+  private readonly channelSubscriptions = new Map<string, Promise<unknown>>()
   private readonly queues = new Set<Queue>()
 
   constructor(opts: NamespaceOptions) {
@@ -48,9 +49,10 @@ export class Namespace {
     if (!set) {
       set = new Set()
       this.channelListeners.set(channel, set)
-      await this.subscriber.subscribe(channel)
+      this.channelSubscriptions.set(channel, this.subscriber.subscribe(channel))
     }
     set.add(cb)
+    await this.channelSubscriptions.get(channel)
   }
 
   /** Remove a waiter; unsubscribes once the channel has no listeners. */
@@ -59,9 +61,17 @@ export class Namespace {
     if (!set) return
     set.delete(cb)
     if (set.size === 0) {
+      await this.channelSubscriptions.get(channel)
+      if (set.size > 0) return
       this.channelListeners.delete(channel)
+      this.channelSubscriptions.delete(channel)
       await this.subscriber.unsubscribe(channel)
     }
+  }
+
+  /** Wait until this connection has dispatched every Pub/Sub message Redis sent before the ping. */
+  async flushWaiters(): Promise<void> {
+    await this.subscriber.ping()
   }
 
   /** Drains and closes every queue, then disconnects the shared + pub/sub connections. */

--- a/src/queue/queue.ts
+++ b/src/queue/queue.ts
@@ -2,11 +2,13 @@ import type { Namespace } from './namespace'
 import type { QueueRedis } from './scripts'
 import type {
   AddOptions,
+  QueueEvent,
   QueueMetrics,
   QueueOptions,
   ScheduleInfo,
   ScheduleOptions,
   WaitOptions,
+  WatchOptions,
   WorkerOptions,
   WorkflowLogger,
 } from './types'
@@ -93,33 +95,103 @@ export class Queue {
    * Throws `TimeoutError`, `ResultExpiredError`, or the job's own failure.
    */
   async wait(jobId: string, opts?: WaitOptions): Promise<string> {
+    const controller = new AbortController()
+    const timer =
+      opts?.timeoutMs === undefined
+        ? undefined
+        : setTimeout(() => controller.abort(new TimeoutError(jobId)), opts.timeoutMs)
+    try {
+      for await (const event of await this.watch(jobId, { signal: controller.signal })) {
+        if (event.type === 'completed') return event.output
+        if (event.type === 'failed') throw event.error
+      }
+      throw new ResultExpiredError(jobId)
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+
+  /** Subscribe before checking for an existing result, then stream every later lifecycle event. */
+  async watch(jobId: string, opts?: WatchOptions): Promise<ReadableStream<QueueEvent>> {
     const channel = `${this.prefix}:${this.id}:done:${jobId}`
     const resultKey = `${this.prefix}:${this.id}:result:${jobId}`
+    let controller!: ReadableStreamDefaultController<QueueEvent>
+    let done = false
+    let cleaned = false
+    let processing = Promise.resolve()
+    let notify!: (raw: string) => void
+    let abort!: () => void
 
-    let notify!: (message: string) => void
-    const notified = new Promise<string>((resolve) => {
-      notify = resolve
-    })
-    await this.ns.addWaiter(channel, notify)
-    try {
-      const first = await this.redis.get(resultKey)
-      if (first !== null) return this.parseResult(first)
-
-      if (opts?.timeoutMs === undefined) return await this.resolvePublished(jobId, await notified)
-
-      let timer: NodeJS.Timeout
-      const timedOut = new Promise<null>((resolve) => {
-        timer = setTimeout(() => resolve(null), opts.timeoutMs)
-      })
-      const published = await Promise.race([notified, timedOut])
-      clearTimeout(timer!)
-      if (published === null) throw new TimeoutError(jobId)
-      return await this.resolvePublished(jobId, published)
-    } finally {
-      // Fire-and-forget: the unsubscribe is ordered on the subscriber connection ahead of any
-      // later subscribe, so nothing is lost by not making the caller pay its round-trip.
-      void this.ns.removeWaiter(channel, notify).catch((err) => this.logger?.error?.(err))
+    const cleanup = async () => {
+      if (cleaned) return
+      cleaned = true
+      opts?.signal?.removeEventListener('abort', abort)
+      await this.ns.removeWaiter(channel, notify)
     }
+    const fail = (error: unknown) => {
+      if (done) return
+      done = true
+      controller.error(error)
+      void cleanup().catch((err) => this.logger?.error?.(err))
+    }
+    const emit = async (raw: string) => {
+      if (done) return
+      const event = await this.parsePublished(jobId, raw)
+      controller.enqueue(event)
+      if (event.type === 'completed' || event.type === 'failed') {
+        done = true
+        controller.close()
+        await cleanup()
+      }
+    }
+    notify = (raw: string) => {
+      processing = processing.then(async () => emit(raw)).catch(fail)
+    }
+    abort = () => fail(opts?.signal?.reason)
+    const events = new ReadableStream<QueueEvent>({
+      start: (controller_) => {
+        controller = controller_
+      },
+      cancel: async () => {
+        done = true
+        await cleanup()
+      },
+    })
+
+    try {
+      await this.ns.addWaiter(channel, notify)
+      opts?.signal?.addEventListener('abort', abort, { once: true })
+      if (opts?.signal?.aborted) abort()
+      else {
+        const result = await this.redis.get(resultKey)
+        // GET and Pub/Sub use separate connections. PING the subscriber before using the snapshot
+        // so every event Redis published before that GET is already in `processing`.
+        await this.ns.flushWaiters()
+        await processing
+        if (!done && result !== null) await emit(result)
+        else if (!done && !opts?.allowMissing) {
+          const state = await this.redis.hget(`${this.prefix}:${this.id}:j:${jobId}`, 'state')
+          if (state === null || state === 'failed') {
+            const lateResult = await this.redis.get(resultKey)
+            await this.ns.flushWaiters()
+            await processing
+            if (!done && lateResult !== null) await emit(lateResult)
+            else if (!done) fail(new ResultExpiredError(jobId))
+          }
+        }
+      }
+    } catch (err) {
+      fail(err)
+    }
+    return events
+  }
+
+  /** Publish a transient lifecycle record. Nothing is persisted. */
+  async publish(
+    jobId: string,
+    event: Extract<QueueEvent, { type: 'started' | 'progress' }>,
+  ): Promise<void> {
+    await this.redis.publish(`${this.prefix}:${this.id}:done:${jobId}`, JSON.stringify(event))
   }
 
   /** Persist a step's data (opaque string) — a single atomic `HSET` on the `:steps` hash. */
@@ -137,26 +209,51 @@ export class Queue {
    * wake-up and re-read from the result key (`ResultExpiredError` if it has aged out) — exactly
    * the pre-change behaviour.
    */
-  private async resolvePublished(jobId: string, published: string): Promise<string> {
-    if (published.startsWith('{')) return this.parseResult(published)
-    const stored = await this.redis.get(`${this.prefix}:${this.id}:result:${jobId}`)
-    if (stored === null) throw new ResultExpiredError(jobId)
-    return this.parseResult(stored)
-  }
-
-  private parseResult(raw: string): string {
-    const record = JSON.parse(raw) as {
-      state: string
-      value?: string
-      reason?: string
-      stack?: string
+  private async parsePublished(jobId: string, published: string): Promise<QueueEvent> {
+    if (!published.startsWith('{')) {
+      const stored = await this.redis.get(`${this.prefix}:${this.id}:result:${jobId}`)
+      if (stored === null) throw new ResultExpiredError(jobId)
+      return this.parsePublished(jobId, stored)
     }
-    if (record.state === 'failed') {
-      const error = new Error(record.reason ?? 'job failed')
-      if (record.stack) error.stack = record.stack
-      throw error
+    const record: unknown = JSON.parse(published)
+    if (typeof record !== 'object' || record === null)
+      throw new Error(`Invalid job event for ${jobId}`)
+    if (
+      'type' in record &&
+      record.type === 'started' &&
+      'attempt' in record &&
+      typeof record.attempt === 'number' &&
+      Number.isInteger(record.attempt) &&
+      record.attempt > 0
+    )
+      return { type: 'started', attempt: record.attempt }
+    if (
+      'type' in record &&
+      record.type === 'progress' &&
+      'data' in record &&
+      typeof record.data === 'string'
+    )
+      return { type: 'progress', data: record.data }
+    if (
+      'state' in record &&
+      record.state === 'failed' &&
+      'reason' in record &&
+      typeof record.reason === 'string' &&
+      (!('stack' in record) || typeof record.stack === 'string')
+    ) {
+      const error = new Error(record.reason)
+      if ('stack' in record && typeof record.stack === 'string' && record.stack)
+        error.stack = record.stack
+      return { type: 'failed', error }
     }
-    return record.value ?? ''
+    if (
+      'state' in record &&
+      record.state === 'completed' &&
+      'value' in record &&
+      typeof record.value === 'string'
+    )
+      return { type: 'completed', output: record.value }
+    throw new Error(`Invalid job event for ${jobId}`)
   }
 
   /**

--- a/src/queue/types.ts
+++ b/src/queue/types.ts
@@ -125,6 +125,18 @@ export interface WaitOptions {
   timeoutMs?: number
 }
 
+export interface WatchOptions {
+  signal?: AbortSignal
+  /** Internal: `runAndWatch` subscribes before the job exists. */
+  allowMissing?: boolean
+}
+
+export type QueueEvent =
+  | { type: 'started'; attempt: number }
+  | { type: 'progress'; data: string }
+  | { type: 'completed'; output: string }
+  | { type: 'failed'; error: Error }
+
 /** A job handed to a worker handler — a frozen value, not a class. */
 export interface ReservedJob {
   id: string

--- a/src/queue/worker.ts
+++ b/src/queue/worker.ts
@@ -280,7 +280,14 @@ export class Worker {
     const controller = new AbortController()
     const stopHeartbeat = this.startHeartbeat(claim, controller)
     try {
+      const started = this.queue
+        .publish(claim.job.id, {
+          type: 'started',
+          attempt: claim.job.attemptsMade + 1,
+        })
+        .catch(this.onError)
       const result = await this.handler(claim.job, { signal: controller.signal })
+      await started
       // Abort-on-lost-claim: the heartbeat aborted because the claim was recovered
       // and re-reserved elsewhere — drop the job without committing. The token-guard on
       // complete/fail makes those no-ops anyway, but skipping avoids the wasted round-trip.

--- a/src/step.ts
+++ b/src/step.ts
@@ -15,7 +15,7 @@ export type WorkflowStepData =
       startedAt: number
     }
 
-export class WorkflowStep {
+export class WorkflowStep<Progress = never> {
   private workflowId
   private queue
   private workflowJobId
@@ -49,7 +49,7 @@ export class WorkflowStep {
     return `${this.stepNamePrefix}${name}`
   }
 
-  async do<R>(stepName: string, run: (ctx: { step: WorkflowStep; span: Span }) => R) {
+  async do<R>(stepName: string, run: (ctx: { step: WorkflowStep<Progress>; span: Span }) => R) {
     const name = this.addNamePrefix(stepName)
 
     // Memoize on completion only: a stored `result` field means the step finished on a prior
@@ -77,7 +77,7 @@ export class WorkflowStep {
       },
       async (span) => {
         const result = await run({
-          step: new WorkflowStep({
+          step: new WorkflowStep<Progress>({
             queue: this.queue,
             workflowId: this.workflowId,
             workflowJobId: this.workflowJobId,
@@ -99,6 +99,10 @@ export class WorkflowStep {
 
     this.stepPromises.add(promise)
     return promise.finally(() => this.stepPromises.delete(promise))
+  }
+
+  async progress(data: Progress): Promise<void> {
+    await this.queue.publish(this.workflowJobId, { type: 'progress', data: serialize(data) })
   }
 
   async wait(stepName: string, durationMs: number) {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -11,6 +11,7 @@ import type {
   WorkflowLogger,
 } from './queue'
 import type { WorkflowJobPayloadInternal, WorkflowQueueInternal } from './types'
+import { randomUUID } from 'node:crypto'
 import { context, propagation, ROOT_CONTEXT, SpanKind } from '@opentelemetry/api'
 import { asyncExitHook } from 'exit-hook'
 import { WorkflowJob } from './job'
@@ -19,6 +20,8 @@ import { deserialize, serialize } from './serializer'
 import { defaultRedisConnection } from './settings'
 import { WorkflowStep } from './step'
 import { runWithTracing } from './tracer'
+
+export type { WorkflowEvent } from './job'
 
 /** Per-workflow queue overrides (module `QueueOptions` minus the id). */
 export type WorkflowQueueOptions = Omit<QueueOptions, 'id'>
@@ -51,10 +54,17 @@ export interface WorkflowNamespaceOptions {
   jobOptions?: WorkflowJobRunOptions
 }
 
-export interface CreateWorkflowOptions<RunInput, Input, Output> {
+export interface CreateWorkflowOptions<
+  RunInput,
+  Input,
+  Output,
+  ProgressInput = never,
+  Progress = ProgressInput,
+> {
   id: string
   schema?: StandardSchemaV1<RunInput, Input>
-  run: (ctx: WorkflowRunContext<Input>) => Promise<Output>
+  progressSchema?: StandardSchemaV1<ProgressInput, Progress>
+  run: (ctx: WorkflowRunContext<Input, ProgressInput>) => Promise<Output>
   getGroupId?: (
     input: IsUnknown<Input> extends true ? undefined : Input,
   ) => string | undefined | Promise<string | undefined>
@@ -120,9 +130,15 @@ export class WorkflowNamespace {
     return this.namespace
   }
 
-  createWorkflow<RunInput, Input = RunInput, Output = unknown>(
-    opts: CreateWorkflowOptions<RunInput, Input, Output>,
-  ): Workflow<RunInput, Input, Output> {
+  createWorkflow<
+    RunInput,
+    Input = RunInput,
+    Output = unknown,
+    ProgressInput = never,
+    Progress = ProgressInput,
+  >(
+    opts: CreateWorkflowOptions<RunInput, Input, Output, ProgressInput, Progress>,
+  ): Workflow<RunInput, Input, Output, ProgressInput, Progress> {
     return new Workflow(this, {
       ...opts,
       queueOptions: { ...this.opts.queueOptions, ...opts.queueOptions },
@@ -142,13 +158,16 @@ export class WorkflowNamespace {
   }
 }
 
-export class Workflow<RunInput, Input, Output> {
+export class Workflow<RunInput, Input, Output, ProgressInput = never, Progress = ProgressInput> {
   readonly id: string
   private readonly ns: WorkflowNamespace
-  private readonly opts: CreateWorkflowOptions<RunInput, Input, Output>
+  private readonly opts: CreateWorkflowOptions<RunInput, Input, Output, ProgressInput, Progress>
   private queue?: Promise<WorkflowQueueInternal>
 
-  constructor(ns: WorkflowNamespace, opts: CreateWorkflowOptions<RunInput, Input, Output>) {
+  constructor(
+    ns: WorkflowNamespace,
+    opts: CreateWorkflowOptions<RunInput, Input, Output, ProgressInput, Progress>,
+  ) {
     this.ns = ns
     this.opts = opts
     this.id = opts.id
@@ -212,7 +231,7 @@ export class Workflow<RunInput, Input, Output> {
               const result = await this.opts.run({
                 // eslint-disable-next-line ts/no-unsafe-assignment
                 input: parsedData?.value as any,
-                step: new WorkflowStep({
+                step: new WorkflowStep<ProgressInput>({
                   queue,
                   workflowJobId: job.id,
                   workflowId: this.id,
@@ -260,8 +279,33 @@ export class Workflow<RunInput, Input, Output> {
     return worker
   }
 
-  async run(input: RunInput, opts?: WorkflowJobRunOptions): Promise<WorkflowJob<Output>> {
+  async run(input: RunInput, opts?: WorkflowJobRunOptions): Promise<WorkflowJob<Output, Progress>> {
     return this.enqueue(input, opts)
+  }
+
+  async runAndWatch(input: RunInput, opts?: WorkflowJobRunOptions) {
+    const jobId = opts?.jobId ?? this.opts.jobOptions?.jobId ?? randomUUID()
+    const events = await new WorkflowJob<Output, Progress>({
+      queue: await this.getQueue(),
+      jobId,
+      progressSchema: this.opts.progressSchema,
+      watchBeforeEnqueue: true,
+    }).watch()
+    try {
+      const job = await this.enqueue(input, { ...opts, jobId })
+      return { job, events }
+    } catch (err) {
+      await events.cancel(err)
+      throw err
+    }
+  }
+
+  async getJob(jobId: string): Promise<WorkflowJob<Output, Progress>> {
+    return new WorkflowJob<Output, Progress>({
+      queue: await this.getQueue(),
+      jobId,
+      progressSchema: this.opts.progressSchema,
+    })
   }
 
   async runIn(input: RunInput, delayMs: number, opts?: WorkflowJobRunOptions) {
@@ -275,7 +319,7 @@ export class Workflow<RunInput, Input, Output> {
   private async enqueue(
     input: RunInput,
     opts?: WorkflowJobRunOptions & { runAt?: number; runIn?: number },
-  ): Promise<WorkflowJob<Output>> {
+  ): Promise<WorkflowJob<Output, Progress>> {
     const parsedInput = this.opts.schema && (await this.opts.schema['~standard'].validate(input))
     if (parsedInput?.issues) throw new Error('Invalid workflow input')
 
@@ -315,7 +359,11 @@ export class Workflow<RunInput, Input, Output> {
           },
         )
 
-        return new WorkflowJob<Output>({ queue, jobId: job.id, groupId: job.groupId })
+        return new WorkflowJob<Output, Progress>({
+          queue,
+          jobId: job.id,
+          progressSchema: this.opts.progressSchema,
+        })
       },
     )
   }
@@ -387,8 +435,8 @@ export class Workflow<RunInput, Input, Output> {
   }
 }
 
-export interface WorkflowRunContext<Input> {
+export interface WorkflowRunContext<Input, Progress = never> {
   input: IsUnknown<Input> extends true ? undefined : Input
-  step: WorkflowStep
+  step: WorkflowStep<Progress>
   span: Span
 }

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -4,6 +4,7 @@ import { sleep } from '@antfu/utils'
 import { type } from 'arktype'
 import { stringify } from 'superjson'
 import { beforeAll, describe, expect, test, vi } from 'vitest'
+import { z } from 'zod'
 import { createRedis, ResultExpiredError, TimeoutError, WorkflowNamespace } from '../src'
 
 let sharedRedis: Awaited<ReturnType<typeof createRedis>>
@@ -44,6 +45,12 @@ function passthrough<T>(): StandardSchemaV1<T, T> {
       validate: (value) => ({ value: value as T }),
     },
   }
+}
+
+async function collect<T>(events: AsyncIterable<T>): Promise<T[]> {
+  const result: T[] = []
+  for await (const event of events) result.push(event)
+  return result
 }
 
 describe('input', () => {
@@ -149,6 +156,330 @@ describe('wait', () => {
     } finally {
       await ns.close()
     }
+  })
+})
+
+describe('watch', () => {
+  test('yields the attempt and output in emission order, then ends', async () => {
+    const workflow = namespace().createWorkflow({
+      id: randomUUID(),
+      run: async () => 'done',
+    })
+    const job = await workflow.run(undefined)
+    const events = await job.watch()
+    await workflow.work()
+
+    const received = await collect(events)
+
+    expect(received).toEqual([
+      { type: 'started', attempt: 1 },
+      { type: 'completed', output: 'done' },
+    ])
+  })
+
+  test('yields a terminal failure instead of throwing from the stream', async () => {
+    const workflow = namespace().createWorkflow({
+      id: randomUUID(),
+      run: async () => {
+        throw new Error('boom')
+      },
+    })
+    const job = await workflow.run(undefined)
+    const events = await job.watch()
+    await workflow.work()
+
+    const received = await collect(events)
+
+    expect(received[0]).toEqual({ type: 'started', attempt: 1 })
+    expect(received[1]).toMatchObject({ type: 'failed', error: { message: 'boom' } })
+  })
+
+  test('emits another start after a retry and no intermediate failure', async () => {
+    let attempts = 0
+    const workflow = namespace().createWorkflow({
+      id: randomUUID(),
+      workerOptions: { maxAttempts: 2 },
+      run: async () => {
+        if (attempts++ === 0) throw new Error('retry me')
+        return 'done'
+      },
+    })
+    const job = await workflow.run(undefined)
+    const events = await job.watch()
+    await workflow.work({ backoff: () => 0 })
+
+    const received = await collect(events)
+
+    expect(received).toEqual([
+      { type: 'started', attempt: 1 },
+      { type: 'started', attempt: 2 },
+      { type: 'completed', output: 'done' },
+    ])
+  })
+
+  test('gives two watchers the complete stream independently', async () => {
+    const workflow = namespace().createWorkflow({ id: randomUUID(), run: async () => 'done' })
+    const job = await workflow.run(undefined)
+    const watchers = await Promise.all([job.watch(), job.watch()])
+    await workflow.work()
+
+    const received = await Promise.all(watchers.map(collect))
+
+    expect(received[0]).toEqual(received[1])
+    expect(received[0]).toEqual([
+      { type: 'started', attempt: 1 },
+      { type: 'completed', output: 'done' },
+    ])
+  })
+
+  test('unsubscribes when iteration stops early', async () => {
+    const gate = makeGate()
+    const workflow = namespace().createWorkflow({
+      id: randomUUID(),
+      run: async () => {
+        await gate.wait()
+        return 'done'
+      },
+    })
+    const job = await workflow.run(undefined)
+    const [earlyEvents, completeEvents] = await Promise.all([job.watch(), job.watch()])
+    await workflow.work()
+    const completeReceived = collect(completeEvents)
+    const earlyReceived = []
+
+    try {
+      for await (const event of earlyEvents) {
+        earlyReceived.push(event)
+        if (event.type === 'started') break
+      }
+    } finally {
+      gate.open()
+    }
+
+    expect(earlyReceived).toEqual([{ type: 'started', attempt: 1 }])
+    await expect(completeReceived).resolves.toEqual([
+      { type: 'started', attempt: 1 },
+      { type: 'completed', output: 'done' },
+    ])
+  })
+
+  test('returns the terminal event when the job already finished', async () => {
+    const workflow = namespace().createWorkflow({ id: randomUUID(), run: async () => 'done' })
+    await workflow.work()
+    const job = await workflow.run(undefined)
+    await job.wait()
+
+    const received = await collect(await job.watch())
+
+    expect(received).toEqual([{ type: 'completed', output: 'done' }])
+  })
+
+  test('throws ResultExpiredError after the terminal result window', async () => {
+    const workflow = namespace().createWorkflow({
+      id: randomUUID(),
+      queueOptions: { resultTtl: 1 },
+      run: async () => 'done',
+    })
+    const { job, events: initialEvents } = await workflow.runAndWatch(undefined)
+    await workflow.work()
+    await collect(initialEvents)
+    await sleep(1100)
+
+    const events = await job.watch()
+    const next = events[Symbol.asyncIterator]().next()
+
+    await expect(
+      Promise.race([
+        next,
+        sleep(100).then(() => {
+          throw new Error('watch hung')
+        }),
+      ]),
+    ).rejects.toBeInstanceOf(ResultExpiredError)
+  })
+
+  test('accepts an AbortSignal', async () => {
+    const workflow = namespace().createWorkflow({ id: randomUUID(), run: async () => 'never' })
+    const job = await workflow.run(undefined)
+    const controller = new AbortController()
+    const events = await job.watch({ signal: controller.signal })
+    const reason = new Error('stop watching')
+
+    controller.abort(reason)
+
+    await expect(events[Symbol.asyncIterator]().next()).rejects.toBe(reason)
+  })
+
+  test('validates and yields progress emitted from a nested step', async () => {
+    const workflow = namespace().createWorkflow({
+      id: randomUUID(),
+      schema: type({ name: 'string' }),
+      progressSchema: type({ label: 'string', done: 'number' }),
+      run: async ({ input, step }) => {
+        input.name satisfies string
+        await step.do('outer', async ({ step: nestedStep }) => {
+          await nestedStep.progress({ label: 'Rendering', done: 1 })
+          await nestedStep.progress({ label: 'Uploading', done: 2 })
+        })
+        return 'done'
+      },
+    })
+    const job = await workflow.run({ name: 'report' })
+    const events = await job.watch()
+    await workflow.work()
+
+    const received = await collect(events)
+
+    expect(received).toEqual([
+      { type: 'started', attempt: 1 },
+      { type: 'progress', data: { label: 'Rendering', done: 1 } },
+      { type: 'progress', data: { label: 'Uploading', done: 2 } },
+      { type: 'completed', output: 'done' },
+    ])
+  })
+
+  test('removes progress from workflows without a schema', async () => {
+    const workflow = namespace().createWorkflow({
+      id: randomUUID(),
+      run: async ({ step }) => {
+        if (false) {
+          // @ts-expect-error progress is unavailable without a progress schema
+          await step.progress('undeclared')
+        }
+        return 'done'
+      },
+    })
+    const job = await workflow.run(undefined)
+    const events = await job.watch()
+    await workflow.work()
+
+    for await (const event of events) {
+      // @ts-expect-error the progress arm vanishes when Progress is never
+      if (event.type === 'progress') throw new Error('unreachable')
+    }
+  })
+
+  test('splits schema input from validated output', async () => {
+    const workflow = namespace().createWorkflow({
+      id: randomUUID(),
+      schema: z.object({ id: z.string() }),
+      progressSchema: z.object({
+        value: z.string().transform(Number),
+        label: z.string().default('Working'),
+      }),
+      run: async ({ input, step }) => {
+        input.id satisfies string
+        await step.progress({ value: '42' })
+        return input.id
+      },
+    })
+    const job = await workflow.run({ id: 'report' })
+    const events = await job.watch()
+    await workflow.work()
+
+    for await (const event of events) {
+      if (event.type === 'progress') {
+        event.data.value satisfies number
+        event.data.label satisfies string
+        expect(event.data).toEqual({ value: 42, label: 'Working' })
+      }
+    }
+  })
+
+  test('keeps a union progress payload in the event type', async () => {
+    const workflow = namespace().createWorkflow({
+      id: randomUUID(),
+      progressSchema: type('string | number'),
+      run: async ({ step }) => {
+        await step.progress(1)
+        return 'done'
+      },
+    })
+    const job = await workflow.run(undefined)
+    const events = await job.watch()
+    await workflow.work()
+
+    for await (const event of events) {
+      if (event.type === 'progress') expect(event.data satisfies string | number).toBe(1)
+    }
+  })
+
+  test('rejects progress that fails receive-side validation', async () => {
+    const workflow = namespace().createWorkflow({
+      id: randomUUID(),
+      progressSchema: type({ done: 'number' }),
+      run: async ({ step }) => {
+        await step.progress({ done: 'wrong' } as unknown as { done: number })
+        return 'done'
+      },
+    })
+    const job = await workflow.run(undefined)
+    const events = await job.watch()
+    const iterator = events[Symbol.asyncIterator]()
+    await workflow.work()
+
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: { type: 'started', attempt: 1 },
+    })
+    await expect(iterator.next()).rejects.toThrow(`Invalid workflow progress for job ${job.id}`)
+  })
+
+  test('does not re-emit progress from a cached step on retry', async () => {
+    let attempts = 0
+    const workflow = namespace().createWorkflow({
+      id: randomUUID(),
+      progressSchema: type({ label: 'string' }),
+      workerOptions: { maxAttempts: 2 },
+      run: async ({ step }) => {
+        await step.do('cached', async ({ step: nestedStep }) => {
+          await nestedStep.progress({ label: 'Running once' })
+          return 'cached'
+        })
+        if (attempts++ === 0) throw new Error('retry')
+        return 'done'
+      },
+    })
+    const job = await workflow.run(undefined)
+    const events = await job.watch()
+    await workflow.work({ backoff: () => 0 })
+
+    const received = await collect(events)
+
+    expect(received).toEqual([
+      { type: 'started', attempt: 1 },
+      { type: 'progress', data: { label: 'Running once' } },
+      { type: 'started', attempt: 2 },
+      { type: 'completed', output: 'done' },
+    ])
+  })
+
+  test('runAndWatch attaches before enqueueing', async () => {
+    const workflow = namespace().createWorkflow({ id: randomUUID(), run: async () => 'done' })
+    const { job, events } = await workflow.runAndWatch(undefined)
+    await workflow.work()
+
+    const received = await collect(events)
+
+    expect(job.id).toMatch(/^[0-9a-f-]{36}$/i)
+    expect(received).toEqual([
+      { type: 'started', attempt: 1 },
+      { type: 'completed', output: 'done' },
+    ])
+  })
+
+  test('rehydrates a typed job handle from its id on a producer-only namespace', async () => {
+    const workflowId = randomUUID()
+    const producer = namespace().createWorkflow({ id: workflowId, run: async () => 'done' })
+    const observer = namespace().createWorkflow({ id: workflowId, run: async () => 'unused' })
+    const job = await producer.run(undefined)
+    const attached = await observer.getJob(job.id)
+    const watchers = await Promise.all([job.watch(), attached.watch()])
+    await producer.work()
+
+    const received = await Promise.all(watchers.map(collect))
+
+    expect(attached.id).toBe(job.id)
+    expect(received[0]).toEqual(received[1])
   })
 })
 
@@ -285,29 +616,17 @@ describe('step', () => {
 })
 
 describe('groups', () => {
-  test('random id if not specified', async () => {
-    const workflow = namespace().createWorkflow({
-      id: randomUUID(),
-      schema: type({ name: 'string' }),
-      run: async () => {},
-    })
-    await workflow.work()
-    const job = await workflow.run({ name: 'A' })
-
-    expect(job.groupId).toMatch(/^[0-9a-f-]{36}$/i)
-  })
-
-  test('uses specified groupId getter', async () => {
+  test('does not expose groupId on the public job handle', async () => {
     const workflow = namespace().createWorkflow({
       id: randomUUID(),
       schema: type({ name: 'string' }),
       getGroupId: (input) => `group-for-${input.name}`,
       run: async () => {},
     })
-    await workflow.work()
     const job = await workflow.run({ name: 'A' })
 
-    expect(job.groupId).toBe('group-for-A')
+    // @ts-expect-error groupId is worker-internal, not part of a producer's handle
+    expect(job.groupId).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
Jobs are opaque between enqueue and their terminal result. Consumers cannot observe attempts or typed progress, safely subscribe before enqueue, or reconstruct a typed handle from a known job id.

This introduces an eagerly subscribed `job.watch()` stream for lifecycle, progress, and terminal events. Progress is validated through Standard Schema, nested steps can emit it, `runAndWatch()` closes the enqueue race, and `getJob(jobId)` supports producer-only reattachment. Lifecycle and progress records remain transient.

> [!WARNING]
> This release requires a full process restart. `WorkflowJob.groupId` is removed, and older peers can misread lifecycle or progress records on the shared completion channel. Do not rolling-deploy this version with an older release.

## Reviews

| Review | Found | Fixed |
| --- | ---: | ---: |
| Standards | 3 | 3 |
| Spec | 5 | 5 |
| Ponytail ultra | 1 | 1 |

All follow-up review passes are clean.

## Verification

- `pnpm type-check`
- `pnpm lint`
- `pnpm test` with 90 passing tests
- `pnpm build`

Closes #23
Closes #24
Closes #25
Closes #26